### PR TITLE
Multilabel Regression with Scikit learn (Random Forests)

### DIFF
--- a/dgbpy/dgbscikit.py
+++ b/dgbpy/dgbscikit.py
@@ -22,6 +22,7 @@ from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegress
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 from sklearn.svm import LinearSVC, LinearSVR, SVC, SVR
+from sklearn.multioutput import MultiOutputRegressor
 
 from sklearn.cluster import KMeans, MeanShift, SpectralClustering
 
@@ -97,11 +98,13 @@ def getMLPlatform():
 def getUIMLPlatform():
   return platform[1]
 
-def getUiModelTypes(learntype,isclassification):
+def getUiModelTypes(learntype,isclassification,ismultiregression):
   if dgbhdf5.isSegmentation(learntype):
     return getUiClusterTypes()
   if isclassification:
     return dgbkeys.getNames( classmltypes )
+  if ismultiregression:
+    return dgbkeys.getNames( (regmltypes[1],) )
   return dgbkeys.getNames( regmltypes )
 
 def getUiLinearTypes():
@@ -116,7 +119,9 @@ def getUiClusterTypes():
 def getUiClusterMethods():
   return dgbkeys.getNames( clustermethods )
 
-def getUiEnsembleTypes():
+def getUiEnsembleTypes(ismultiregression):
+  if ismultiregression:
+    return dgbkeys.getNames( (ensembletypes[2],) )
   return dgbkeys.getNames( ensembletypes )
 
 def getUiNNTypes():
@@ -428,6 +433,10 @@ def unscale( samples, scaler ):
 def getDefaultModel( setup, params=scikit_dict ):
   modelname = params['modelname']
   isclassification = setup[dgbhdf5.classdictstr]
+  ismultilabelregression = dgbhdf5.isMultiLabelRegression(setup)
+  if ismultilabelregression and modelname != 'Random Forests':
+    log_msg('Multilabel prediction is only supported for Random Forest in Scikit')   
+    return None
   try:
     if modelname =='Clustering':
       method = params['methodname']
@@ -467,6 +476,8 @@ def getDefaultModel( setup, params=scikit_dict ):
       max_depth = params['maxdep']
       if isclassification:
         model = RandomForestClassifier(n_estimators=n_estimators,criterion='gini',max_depth=max_depth,n_jobs=-1)
+      elif ismultilabelregression:
+        model = MultiOutputRegressor(RandomForestRegressor(n_estimators=n_estimators,criterion='mse',max_depth=max_depth,n_jobs=-1))
       else:
         model = RandomForestRegressor(n_estimators=n_estimators,criterion='mse',max_depth=max_depth,n_jobs=-1)
     elif modelname == 'Gradient Boosting':
@@ -519,7 +530,10 @@ def getDefaultModel( setup, params=scikit_dict ):
 
 def train(model, trainingdp):
   x_train = trainingdp[dgbkeys.xtraindictstr]
-  y_train = trainingdp[dgbkeys.ytraindictstr].ravel()
+  if dgbhdf5.isMultiLabelRegression(trainingdp[dgbkeys.infodictstr]):
+    y_train = trainingdp[dgbkeys.ytraindictstr]
+  else:
+    y_train = trainingdp[dgbkeys.ytraindictstr].ravel()
   printProcessTime( 'Training with scikit-learn', True, print_fn=log_msg )
   log_msg( '\nTraining on', len(y_train), 'samples' )
   log_msg( 'Validate on', len(trainingdp[dgbkeys.yvaliddictstr]), 'samples\n' )
@@ -536,7 +550,10 @@ def assessQuality( model, trainingdp ):
     return
   try:
     x_validate = trainingdp[dgbkeys.xvaliddictstr]
-    y_validate = trainingdp[dgbkeys.yvaliddictstr].ravel()
+    if dgbhdf5.isMultiLabelRegression(trainingdp[dgbkeys.infodictstr]):
+      y_validate = trainingdp[dgbkeys.yvaliddictstr]
+    else:
+      y_validate = trainingdp[dgbkeys.yvaliddictstr].ravel()
     y_predicted = model.predict(x_validate)
     if trainingdp[dgbkeys.infodictstr][dgbkeys.classdictstr]:
       cc = np.sum( y_predicted==y_validate) / len(y_predicted)
@@ -568,7 +585,11 @@ def save( model, outfnm, save_type=defsavetype ):
   odhdf5.setAttr( h5file, 'backend', 'scikit-learn' )
   odhdf5.setAttr( h5file, 'sklearn_version', sklearn.__version__ )
   odhdf5.setAttr( h5file, 'type', model.__class__.__name__ )
-  odhdf5.setAttr( h5file, 'model_config', json.dumps(model.get_params()) )
+  if isinstance(model, MultiOutputRegressor):
+    params = {key:value for key,value in model.get_params().items() if key != "estimator"}
+    odhdf5.setAttr( h5file, 'model_config', json.dumps(params) )
+  else:
+    odhdf5.setAttr( h5file, 'model_config', json.dumps(model.get_params()) )
   modelgrp = h5file.create_group( 'model' )
   if hasXGBoost():
     from xgboost import XGBClassifier, XGBRegressor, \

--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -123,6 +123,11 @@ def isImg2Img( info ):
 def isModel( info ):
   return plfdictstr in info
 
+def isMultiLabelRegression( info ):
+  if not isRegression( info ) or isImg2Img( info ):
+    return False
+  return getNrOutputs( info ) > 1
+
 def getOutdType( classinfo ):
   max = classinfo.max()
   min = classinfo.min()

--- a/dgbpy/uisklearn.py
+++ b/dgbpy/uisklearn.py
@@ -117,6 +117,7 @@ def getEnsembleGrp(uipars=None):
   rfgrp = {}
   xgdtgrp = None
   xgrfgrp = None
+  ismultiregression = dgbhdf5.isMultiLabelRegression(info)
   if uipars:
     uiobjs  = uipars['uiobjects']
     if hasXGBoost():
@@ -147,7 +148,7 @@ def getEnsembleGrp(uipars=None):
     gbgrp = getGBGrp()
     adagrp = getAdaGrp()
     uiobjs = {'ensembletyp': Select(title='Model',
-                             options=getUiEnsembleTypes())}
+                             options=getUiEnsembleTypes(ismultiregression))}
     if hasXGBoost():
       xggrpuiobjs = xgdtgrp['uiobjects']
       uiobjs.update({
@@ -170,16 +171,19 @@ def getEnsembleGrp(uipars=None):
               'estparfldada': adagrp['uiobjects']['estparfldada'],
               'lrparfldada': adagrp['uiobjects']['lrparfldada'],
               })
-    if hasXGBoost():
-      ensemblegrp = (xgdtgrp,xgrfgrp,rfgrp,gbgrp,adagrp)
+    if not ismultiregression:
+      if hasXGBoost():
+        ensemblegrp = (xgdtgrp,xgrfgrp,rfgrp,gbgrp,adagrp)
+      else: 
+        ensemblegrp = (rfgrp,gbgrp,adagrp)  
+      uiobjs['ensembletyp'].on_change('value',partial(ensembleChgCB,cb=uiobjs['ensembletyp'],ensemblegrp=ensemblegrp))
     else:
-      ensemblegrp = (rfgrp,gbgrp,adagrp)
-    uiobjs['ensembletyp'].on_change('value',partial(ensembleChgCB,cb=uiobjs['ensembletyp'],ensemblegrp=ensemblegrp))
+      ensemblegrp = (rfgrp,)
     uipars = {'uiobjects': uiobjs, 'name': regmltypes[1][1],}
 
-  if hasXGBoost():
+  if hasXGBoost() and not ismultiregression:
     uiobjs['ensembletyp'].value = 'XGBoost: (Decision Tree)'
-  else:
+  elif ismultiregression or not hasXGBoost():
     uiobjs['ensembletyp'].value = 'Random Forests'
   return uipars
 
@@ -475,7 +479,7 @@ def ensembleChgCB( attrnm, old, new, cb, ensemblegrp ):
 def getUiClusterPars( uipars=None ):
   learntype = info[dgbkeys.learntypedictstr]
   isclassification = info[dgbkeys.classdictstr]
-  models = getUiModelTypes(learntype,isclassification)
+  models = getUiModelTypes(learntype,isclassification, None)
 
   if len(models)==0:
     divfld = Div(text="""No scikit-learn models found for this workflow.""")
@@ -507,8 +511,8 @@ def getUiPars(uipars=None):
     return getUiClusterPars( uipars )
 
   isclassification = info[dgbkeys.classdictstr]
-  models = getUiModelTypes(learntype,isclassification)
-
+  ismultiregression = dgbhdf5.isMultiLabelRegression(info)
+  models = getUiModelTypes(learntype,isclassification, ismultiregression)
   if len(models)==0:
       divfld = Div(text="""No scikit-learn models found for this workflow.""")
       parsgrp = column(divfld)
@@ -528,52 +532,60 @@ def getUiPars(uipars=None):
       'svmgrp': getSVMGrp( isclassification, uipars=None )
     }
     modelsgrp = (uiobjs[linearkey], uiobjs['ensemblegrp'], uiobjs['nngrp'], uiobjs['svmgrp'])
-    uiobjs['modeltyp'].on_change('value',partial(modelChgCB,cb=uiobjs['modeltyp'],modelsgrp=modelsgrp))
+    if not ismultiregression:
+      uiobjs['modeltyp'].on_change('value',partial(modelChgCB,cb=uiobjs['modeltyp'],modelsgrp=modelsgrp))
     pars = [uiobjs['modeltyp']]
     ensemblepars = [uiobjs['ensemblegrp']['uiobjects']['ensembletyp']]
-    if hasXGBoost():
-      xgdtpars = [uiobjs['ensemblegrp']['uiobjects']['estparfldxgdt'], \
-                  uiobjs['ensemblegrp']['uiobjects']['depparfldxgdt'], \
-                  uiobjs['ensemblegrp']['uiobjects']['lrparfldxgdt'], \
-                 ]
-      xgrfpars = [uiobjs['ensemblegrp']['uiobjects']['estparfldxgrf'], \
-                  uiobjs['ensemblegrp']['uiobjects']['depparfldxgrf'], \
-                  uiobjs['ensemblegrp']['uiobjects']['lrparfldxgrf'], \
-                 ]
-      ensemblepars.extend( xgdtpars )
-      ensemblepars.extend( xgrfpars )
-    ensemblepars.extend([
-                    uiobjs['ensemblegrp']['uiobjects']['estparfldrf'], \
-                    uiobjs['ensemblegrp']['uiobjects']['depparfldrf'], \
-                    uiobjs['ensemblegrp']['uiobjects']['estparfldgb'], \
-                    uiobjs['ensemblegrp']['uiobjects']['depparfldgb'], \
-                    uiobjs['ensemblegrp']['uiobjects']['lrparfldgb'], \
-                    uiobjs['ensemblegrp']['uiobjects']['estparfldada'], \
-                    uiobjs['ensemblegrp']['uiobjects']['lrparfldada'], \
-                   ] )
-    nnpars = [uiobjs['nngrp']['uiobjects']['nntyp'], \
-              uiobjs['nngrp']['uiobjects']['itrparfld'], \
-              uiobjs['nngrp']['uiobjects']['lrparfld'], \
-              uiobjs['nngrp']['uiobjects']['lay1parfld'], \
-              uiobjs['nngrp']['uiobjects']['lay2parfld'], \
-              uiobjs['nngrp']['uiobjects']['lay3parfld'], \
-              uiobjs['nngrp']['uiobjects']['lay4parfld'], \
-              uiobjs['nngrp']['uiobjects']['lay5parfld'], \
-              uiobjs['nngrp']['uiobjects']['buttonparfld'], \
-             ]
-    svmpars = [uiobjs['svmgrp']['uiobjects']['svmtyp'], \
-               uiobjs['svmgrp']['uiobjects']['kernel'], \
-               uiobjs['svmgrp']['uiobjects']['degree'] \
+    if not ismultiregression:
+      if hasXGBoost():
+        xgdtpars = [uiobjs['ensemblegrp']['uiobjects']['estparfldxgdt'], \
+                    uiobjs['ensemblegrp']['uiobjects']['depparfldxgdt'], \
+                    uiobjs['ensemblegrp']['uiobjects']['lrparfldxgdt'], \
+                  ]
+        xgrfpars = [uiobjs['ensemblegrp']['uiobjects']['estparfldxgrf'], \
+                    uiobjs['ensemblegrp']['uiobjects']['depparfldxgrf'], \
+                    uiobjs['ensemblegrp']['uiobjects']['lrparfldxgrf'], \
+                  ]
+        ensemblepars.extend( xgdtpars )
+        ensemblepars.extend( xgrfpars )
+      ensemblepars.extend([
+                      uiobjs['ensemblegrp']['uiobjects']['estparfldrf'], \
+                      uiobjs['ensemblegrp']['uiobjects']['depparfldrf'], \
+                      uiobjs['ensemblegrp']['uiobjects']['estparfldgb'], \
+                      uiobjs['ensemblegrp']['uiobjects']['depparfldgb'], \
+                      uiobjs['ensemblegrp']['uiobjects']['lrparfldgb'], \
+                      uiobjs['ensemblegrp']['uiobjects']['estparfldada'], \
+                      uiobjs['ensemblegrp']['uiobjects']['lrparfldada'], \
+                    ] )
+      nnpars = [uiobjs['nngrp']['uiobjects']['nntyp'], \
+                uiobjs['nngrp']['uiobjects']['itrparfld'], \
+                uiobjs['nngrp']['uiobjects']['lrparfld'], \
+                uiobjs['nngrp']['uiobjects']['lay1parfld'], \
+                uiobjs['nngrp']['uiobjects']['lay2parfld'], \
+                uiobjs['nngrp']['uiobjects']['lay3parfld'], \
+                uiobjs['nngrp']['uiobjects']['lay4parfld'], \
+                uiobjs['nngrp']['uiobjects']['lay5parfld'], \
+                uiobjs['nngrp']['uiobjects']['buttonparfld'], \
               ]
+      svmpars = [uiobjs['svmgrp']['uiobjects']['svmtyp'], \
+                uiobjs['svmgrp']['uiobjects']['kernel'], \
+                uiobjs['svmgrp']['uiobjects']['degree'] \
+                ]
 
-    if isclassification:
-      pars.extend([uiobjs[linearkey]['uiobjects']['logtyp'],
-                   uiobjs[linearkey]['uiobjects']['solvertyp']])
+      if isclassification:
+        pars.extend([uiobjs[linearkey]['uiobjects']['logtyp'],
+                    uiobjs[linearkey]['uiobjects']['solvertyp']])
+      else:
+        pars.extend([uiobjs[linearkey]['uiobjects']['lineartyp']])
+      pars.extend(ensemblepars)
+      pars.extend(nnpars)
+      pars.extend(svmpars)
     else:
-      pars.extend([uiobjs[linearkey]['uiobjects']['lineartyp']])
-    pars.extend(ensemblepars)
-    pars.extend(nnpars)
-    pars.extend(svmpars)
+      ensemblepars.extend([
+                uiobjs['ensemblegrp']['uiobjects']['estparfldrf'], \
+                uiobjs['ensemblegrp']['uiobjects']['depparfldrf'], \
+              ] )
+      pars.extend(ensemblepars)
     parsgrp = column(*pars)
     uipars = {'grp': parsgrp, 'uiobjects': uiobjs}
   else:
@@ -582,15 +594,19 @@ def getUiPars(uipars=None):
   if isclassification:
     uiobjs['modeltyp'].value = models[0]
     uiobjs[linearkey] = getLogGrp(uiobjs[linearkey])
-  else:
+  elif not ismultiregression:
     uiobjs['modeltyp'].value = models[1]
+    uiobjs[linearkey] = getLinearGrp(uiobjs[linearkey])
+  else:
+    uiobjs['modeltyp'].value = models[0]
     uiobjs[linearkey] = getLinearGrp(uiobjs[linearkey])
   uiobjs['ensemblegrp'] = getEnsembleGrp(uiobjs['ensemblegrp'])
   uiobjs['nngrp'] = getNNGrp(uiobjs['nngrp'])
   uiobjs['svmgrp'] = getSVMGrp( isclassification, uipars=uiobjs['svmgrp'])
 
   modelsgrp = (uiobjs[linearkey], uiobjs['ensemblegrp'], uiobjs['nngrp'], uiobjs['svmgrp'])
-  modelChgCB( 'value', deftype, deftype, uiobjs['modeltyp'], modelsgrp )
+  if not ismultiregression:
+    modelChgCB( 'value', deftype, deftype, uiobjs['modeltyp'], modelsgrp )
   return uipars
 
 


### PR DESCRIPTION
- Added a new function that checks for multilabel regression cases
- Used the Multioutput Regressor as a wrapper around sklearn random forests for multilabel regression tasks
- Ensured multilabel tasks only had random forest selection along with its parameters in the application UI for scikit models
