### PR TITLE
fixes for all types of workflows

### DIFF
--- a/dgbpy/dgbkeras.py
+++ b/dgbpy/dgbkeras.py
@@ -55,7 +55,7 @@ defbatchstr = 'defaultbatchsz'
 keras_dict = {
   dgbkeys.decimkeystr: False,
   'nbchunk': 10,
-  'epoch': 15,
+  'epochs': 15,
   'batch': 32,
   'patience': 5,
   'learnrate': 1e-4,
@@ -89,14 +89,14 @@ def set_compute_device( prefercpu ):
   tfconfig.set_visible_devices( cpudevs )
 
 def getParams( dodec=keras_dict[dgbkeys.decimkeystr], nbchunk=keras_dict['nbchunk'],
-               epochs=keras_dict['epoch'],
+               epochs=keras_dict['epochs'],
                batch=keras_dict['batch'], patience=keras_dict['patience'],
                learnrate=keras_dict['learnrate'],epochdrop=keras_dict['epochdrop'],
                nntype=keras_dict['type'],prefercpu=keras_dict['prefercpu']):
   ret = {
     dgbkeys.decimkeystr: dodec,
     'nbchunk': nbchunk,
-    'epoch': epochs,
+    'epochs': epochs,
     'batch': batch,
     'patience': patience,
     'learnrate': learnrate,
@@ -132,7 +132,7 @@ def get_data_format( model ):
   return None
 
 def hasValidCubeletShape( cubeszs ):
-  if cubeszs[0] == None or cubeszs[1] == None or cubeszs[2] == None:
+  if None in cubeszs:
     return False
   return True
 
@@ -302,7 +302,7 @@ def train(model,training,params=keras_dict,trainfile=None,logdir=None,
                          write_graph=True, write_grads=False, write_images=True)
     callbacks.append( tensor_board )
   train_datagen = TrainingSequence( training, False, model, exfilenm=trainfile, batch_size=batchsize, with_augmentation=withaugmentation, tempnm=tempnm )
-  validate_datagen = TrainingSequence( training, True, model, exfilenm=trainfile, batch_size=batchsize, with_augmentation=withaugmentation )
+  validate_datagen = TrainingSequence( training, True, model, exfilenm=trainfile, batch_size=batchsize, with_augmentation=False )
   nbchunks = len( infos[dgbkeys.trainseldicstr] )
   for ichunk in range(nbchunks):
     log_msg('Starting training iteration',str(ichunk+1)+'/'+str(nbchunks))
@@ -335,7 +335,7 @@ def train(model,training,params=keras_dict,trainfile=None,logdir=None,
                             get_validation_data( validate_datagen )
 
     try:
-      model.fit(x=train_datagen,epochs=params['epoch'],verbose=1,
+      model.fit(x=train_datagen,epochs=params['epochs'],verbose=1,
                 validation_data=validate_datagen,callbacks=callbacks)
     except Exception as e:
       log_msg('')

--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -148,6 +148,11 @@ def applyMinMaxScaling( info ):
 def isModel( info ):
   return plfdictstr in info
 
+def isMultiLabelRegression( info ):
+  if not isRegression( info ) or isImg2Img( info ):
+    return False
+  return getNrOutputs( info ) > 1
+
 def getOutdType( classinfo ):
   max = classinfo.max()
   min = classinfo.min()
@@ -504,6 +509,8 @@ def getWellInfo( info, filenm ):
       classesdictstr: getClassIndicesFromData(info),
       classnmdictstr: getMainOutputs(info)[0]
     })
+  else:
+    info[outshapedictstr] = getNrOutputs(info)
 
   if not isModel(info):
     info.update( {estimatedsizedictstr: getTotalSize(info)} )

--- a/dgbpy/keras_classes.py
+++ b/dgbpy/keras_classes.py
@@ -69,7 +69,8 @@ class TrainingSequence(Sequence):
           x_data = trainbatch[dgbkeys.xtraindictstr]
           y_data = trainbatch[dgbkeys.ytraindictstr]
       model = self._model
-      dictinpshape = tuple( info[dgbkeys.inpshapedictstr] )
+      dictinpshape = infos[dgbkeys.inpshapedictstr]
+      dictinpshape = tuple( dictinpshape ) if not isinstance(dictinpshape, int) else (dictinpshape,)
       self._x_data = dgbkeras.adaptToModel( model, x_data, dictinpshape )
       if len(y_data.shape) > 2:
           self._y_data = dgbkeras.adaptToModel( model, y_data, dictinpshape )

--- a/dgbpy/mlmodel_torch_dGB.py
+++ b/dgbpy/mlmodel_torch_dGB.py
@@ -72,7 +72,7 @@ def ResNet18(nroutputs, dim, nrattribs):
     elif dim==2:
       Conv = Conv2d
       BatchNorm = BatchNorm2d
-    elif dim==1:
+    elif dim==1 or dim==0:
       Conv = Conv1d
       BatchNorm = BatchNorm1d
 
@@ -94,7 +94,7 @@ def ResNet18(nroutputs, dim, nrattribs):
       nn.AdaptiveAvgPool2d(output_size = (1, 1)),
       nn.Flatten(),
       nn.Linear(in_features = 4, out_features = nroutputs))
-    elif dim==1:
+    elif dim==1 or dim==0:
       model = nn.Sequential(
       b0, b1,
       nn.AdaptiveAvgPool2d(output_size = (1, 1)),
@@ -112,5 +112,5 @@ class dGB_Simple_Net_Regressor(TorchUserModel):
     def _make_model(self, model_shape, nroutputs, nrattribs):
       from dgbpy.dgbtorch import getModelDims
       ndim = getModelDims(model_shape, 'channels_first')
-      model = Net(output_classes=nroutputs, dim=ndim, nrattribs=nrattribs)
+      model = Net(model_shape=model_shape, output_classes=nroutputs, dim=ndim, nrattribs=nrattribs)
       return model

--- a/dgbpy/uikeras.py
+++ b/dgbpy/uikeras.py
@@ -90,7 +90,7 @@ def getUiPars(uipars=None):
     
   uiobjs['modeltypfld'].value = defmodel
   uiobjs['batchfld'].value = str(defbatchsz)
-  uiobjs['epochfld'].value = dict['epoch']
+  uiobjs['epochfld'].value = dict['epochs']
   uiobjs['patiencefld'].value = dict['patience']
   uiobjs['lrfld'].value = np.log10(dict['learnrate'])
   uiobjs['edfld'].value = 100*dict['epochdrop']/uiobjs['epochfld'].value


### PR DESCRIPTION
- Allows dgbtorch adapt its default model architecture to data input shape.
- Changed "epoch" parameter to "epochs" in keras_dict. This will make parameters in dgbpy more similar.
- Fix check for validCubeletShape since some model shapes might not have the indexes in check.
- Allow RandomForest handle multilabel workflows with sklearn.multioutput.
- Typo fix in keras_classes dictinpshape. Ensure dictinpshape always return a tuple.
- Remove redundant metric calculation in dgbtorch.
- Info dictionary output shape fix for multilabel workflows.