### PR TITLE
Local Scaling Methods & Rotation Transform (Torch)

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -20,10 +20,10 @@ import dgbpy.torch_classes as tc
 
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
-transform_dict = {
-    'RandomFlip':{'p':0.3},
-    'RandomGaussianNoise' :{'p':0.3, 'std':0.3}
-}
+transform_list = [
+    'RandomFlip',
+    'RandomGaussianNoise' 
+]
 
 torch_dict = {
     'epochs': 15,
@@ -32,7 +32,8 @@ torch_dict = {
     'batch_size': 8,
     'learnrate': 0.0001,
     'type': None,
-    'transform':transform_dict
+    'scale': dgbkeys.globalstdtypestr,
+    'transform':transform_list
 }
 platform = (dgbkeys.torchplfnm, 'PyTorch')
 cudacores = [ '1', '2', '4', '8', '16', '32', '48', '64', '96', '128', '144', '192', '256', \
@@ -51,6 +52,7 @@ def getParams(
     epochs=torch_dict['epochs'],
     epochdrop=torch_dict['epochdrop'],
     batch=torch_dict['batch_size'],
+    scale=torch_dict['scale'],
     transform=torch_dict['transform']):
   ret = {
     'type': nntype,
@@ -58,6 +60,7 @@ def getParams(
     'epochs': epochs,
     'epochdrop': epochdrop,
     'batch': batch,
+    'scale': scale,
     'transform': transform
   }
   return ret
@@ -218,7 +221,7 @@ def save( model, outfnm, infos, save_type=defsavetype ):
 
 def train(model, imgdp, params):
     from dgbpy.torch_classes import Trainer
-    trainloader, testloader = DataGenerator(imgdp, batchsize=params['batch'],transform=params['transform'])
+    trainloader, testloader = DataGenerator(imgdp,batchsize=params['batch'],scaler=params['scale'],transform=params['transform'])
     criterion = torch_dict['criterion']
     if imgdp[dgbkeys.infodictstr][dgbkeys.classdictstr]==False:
       criterion = nn.MSELoss()
@@ -241,12 +244,10 @@ def train(model, imgdp, params):
     return model
 
 def apply( model, info, samples, scaler, isclassification, withpred, withprobs, withconfidence, doprobabilities ):
-  if scaler != None:
-    samples = scaler.transform( samples )
   attribs = dgbhdf5.getNrAttribs(info)
   model_shape = get_model_shape(info[dgbkeys.inpshapedictstr], attribs, True)
   ndims = getModelDims(model_shape, 'channels_first')
-  sampleDataset = DatasetApply(samples, isclassification, 1, ndims=ndims)
+  sampleDataset = DatasetApply(samples, info, scaler, isclassification, 1, ndims=ndims)
   ret = {}
   res = None
   try:
@@ -281,9 +282,9 @@ def apply( model, info, samples, scaler, isclassification, withpred, withprobs, 
     elif info[dgbkeys.learntypedictstr] == dgbkeys.seisimgtoimgtypestr:
       from dgbpy.torch_classes import UNet
       if isclassification:
-        dfdm = UNet(out_channels=nroutputs, n_blocks=1, dim=ndims)
+        dfdm = UNet(out_channels=nroutputs, n_blocks=2, dim=ndims)
       else:
-        dfdm = UNet(out_channels=1,  n_blocks=1, dim=ndims)
+        dfdm = UNet(out_channels=1,  n_blocks=2, dim=ndims)
       dfdm.load_state_dict(model)
   elif model.__class__.__name__ == 'OnnxModel':
     dfdm = model
@@ -389,10 +390,10 @@ def getSeismicDatasetPars(imgdp, _forvalid):
     ndims = getModelDims(model_shape, True)
     return x_data, y_data, info, inp_ch, ndims
 
-def DataGenerator(imgdp, batchsize, transform=dict()):
+def DataGenerator(imgdp, batchsize, scaler=None, transform=list()):
     from dgbpy.torch_classes import SeismicTrainDataset, SeismicTestDataset
-    train_dataset = SeismicTrainDataset(imgdp, transform=transform)
-    test_dataset = SeismicTestDataset(imgdp)
+    train_dataset = SeismicTrainDataset(imgdp, scaler, transform=transform)
+    test_dataset = SeismicTestDataset(imgdp, scaler)
 
     trainloader, testloader = getDataLoaders(train_dataset, test_dataset, batchsize)
     return trainloader, testloader

--- a/dgbpy/mlapply.py
+++ b/dgbpy/mlapply.py
@@ -111,7 +111,7 @@ def computeScaler( infos, scalebyattrib, force=False ):
       inp[groupnm].update({dgbkeys.scaledictstr: scaler})
   return infos
 
-def getScaledTrainingData( filenm, flatten=False, scale=True, force=False, 
+def getScaledTrainingData( filenm, flatten=False, scaler=dgbhdf5.Scaler.GlobalScaler, force=False, 
                            nbchunks=1, split=None ):
   """ Gets scaled training data
 
@@ -123,24 +123,21 @@ def getScaledTrainingData( filenm, flatten=False, scale=True, force=False,
     * split (float): size of validation data (between 0-1)
   """
 
-  if isinstance(scale,bool):
-    doscale = scale
-    scalebyattrib = True
-  else:
-    doscale = scale[0]
-    scalebyattrib = len(scale) < 2 or scale[1]
-
   infos = dgbmlio.getInfo( filenm )
   dsets = dgbmlio.getChunks(infos[dgbkeys.datasetdictstr],nbchunks)
   datasets = []
   for dset in dsets:
     datasets.append( dgbmlio.getDatasetNms(dset,validation_split=split) )
   infos.update({dgbkeys.trainseldicstr: datasets})
+
+  scaler, doscale = dgbhdf5.getDefaultScaler(scaler, infos)
+  scalebyattrib = doscale
+  infos = dgbhdf5.updateScaleInfo(scaler, infos)
   if doscale:
     infos = computeScaler( infos, scalebyattrib, force )
   if nbchunks > 1: #Decimate, only need to return the updated info
     return {dgbkeys.infodictstr: infos}
-  return getScaledTrainingDataByInfo( infos, flatten=flatten, scale=scale )
+  return getScaledTrainingDataByInfo( infos, flatten=flatten, scale=doscale )
 
 def getInputList( datasets ):
   """ 
@@ -316,7 +313,8 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
     dgbkeras.set_compute_device( params[dgbkeras.prefercpustr] )
     
     trainingdp = getScaledTrainingData( examplefilenm, flatten=False,
-                                        scale=True, force=False,
+                                        scaler=dgbhdf5.Scaler(params[dgbkeys.scaledictstr]),
+                                        force=False,
                                         nbchunks=params['nbchunk'],
                                         split=validation_split )
     logdir=None
@@ -354,7 +352,8 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
     if params == None:
       params = dgbtorch.getParams()
     trainingdp = getScaledTrainingData( examplefilenm, flatten=False,
-                                        scale=True, force=False,
+                                        scaler=dgbhdf5.Scaler(params[dgbkeys.scaledictstr]),
+                                        force=False,
                                         split=validation_split )
 
     if type == TrainType.New:
@@ -369,7 +368,8 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
     if params == None:
       params = dgbscikit.getParams()
     trainingdp = getScaledTrainingData( examplefilenm, flatten=True,
-                                        scale=True, force=False,
+                                        scaler=dgbhdf5.Scaler(params[dgbkeys.scaledictstr]),
+                                        force=False,
                                         split=validation_split )
     if type == TrainType.New:
       model = dgbscikit.getDefaultModel( trainingdp[dgbkeys.infodictstr],
@@ -530,4 +530,3 @@ def split( arrays, ratio ):
     return None
   nrpts = len(arrays[0])
   np.random.shuffle( np.arange(np.int64(nrpts)) )
-

--- a/dgbpy/mlmodel_torch_dGB.py
+++ b/dgbpy/mlmodel_torch_dGB.py
@@ -18,7 +18,7 @@ class dGB_UnetSeg(TorchUserModel):
   def _make_model(self, model_shape, nroutputs, nrattribs):
     from dgbpy.dgbtorch import getModelDims
     ndim = getModelDims(model_shape, 'channels_first')
-    model = UNet(in_channels=nrattribs, n_blocks=1, out_channels=nroutputs, dim=ndim)
+    model = UNet(in_channels=nrattribs, n_blocks=2, out_channels=nroutputs, dim=ndim)
     return model
 
 from dgbpy.torch_classes import Net, create_resnet_block, UNet
@@ -47,7 +47,7 @@ class dGB_UnetReg(TorchUserModel):
   def _make_model(self, model_shape, nroutputs, nrattribs):
     from dgbpy.dgbtorch import getModelDims
     ndim = getModelDims(model_shape, 'channels_first')
-    model = UNet(in_channels=nrattribs, n_blocks=1, out_channels=nroutputs, dim=ndim)
+    model = UNet(in_channels=nrattribs, n_blocks=2, out_channels=nroutputs, dim=ndim)
     return model
 
 class dGB_ResNet18(TorchUserModel):

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -4,10 +4,11 @@ import numpy as np
 from enum import Enum
 
 from bokeh.layouts import column
-from bokeh.models.widgets import CheckboxGroup, Div, Select, Slider
+from bokeh.models.widgets import CheckboxGroup, Div, Select, Slider, RadioGroup
 
 from odpy.common import log_msg
 from dgbpy.dgbtorch import *
+from dgbpy.torch_classes import hasOpenCV
 import dgbpy.keystr as dgbkeys
 from dgbpy import uibokeh
 
@@ -89,13 +90,15 @@ def getAdvancedUiPars(uipars=None):
   dict = torch_dict
   uiobjs={}
   if not uipars:
+    aug_labels = ['Random Flip', 'Random Gaussian Noise']
+    if hasOpenCV(): aug_labels.append('Random Rotation')
     uiobjs = {
-      'augmentheadfld': CheckboxGroup(labels=['Data Augmentation'], visible=True, margin=(5, 5, 0, 5), active = [0]),
-      'augmentfld': CheckboxGroup(labels=['Random Flip', 'Random Gaussian Noise'], visible=True, margin=(0, 5, 0, 25)),
+      'scalingheadfld' :Div(text="""<strong>Data Scaling</strong>""", height = 10),
+      'scalingfld': RadioGroup(labels=['Global Normalization', 'Local Standardization', 'Local Normalization', 'MinMax Scaling'],
+                               active=0, margin = [5, 5, 5, 25]),
+      'augmentheadfld': Div(text="""<strong>Data Augmentation</strong>""", height = 10),
+      'augmentfld': CheckboxGroup(labels=aug_labels, visible=True, margin=(5, 5, 5, 25)),
     }
-
-    uiobjs['augmentheadfld'].on_click(partial(enableAugmentationCB, widget=uiobjs['augmentfld']))
-
     parsgrp = column(*list(uiobjs.values()))
     uipars = {'grp':parsgrp, 'uiobjects':uiobjs}
   else:
@@ -104,7 +107,6 @@ def getAdvancedUiPars(uipars=None):
   setDefaultTransforms = []
   for transform in dict['transform']:
     setDefaultTransforms.append(uiTransform[transform].value)
-  uiobjs['augmentheadfld'].active = [0]
   uiobjs['augmentfld'].active = setDefaultTransforms
   return uipars     
 
@@ -112,11 +114,15 @@ def enableAugmentationCB(args, widget=None):
   widget.disabled =  uibokeh.integerListContains([widget.disabled], 0)
 
 def getUiTransforms(advtorchgrp):
-  transforms = {}
+  transforms = []
   selectedkeys = advtorchgrp['augmentfld'].active
   for key in selectedkeys:
-    transforms[uiTransform(key).name] = torch_dict['transform'][uiTransform(key).name]
+    transforms.append(uiTransform(key).name)
   return transforms
+
+def getUiScaler(selectedOption):
+  scalers = (dgbkeys.globalstdtypestr, dgbkeys.localstdtypestr, dgbkeys.normalizetypestr, dgbkeys.minmaxtypestr)
+  return scalers[selectedOption]
 
 def getUiParams( torchpars, advtorchpars ):
   torchgrp = torchpars['uiobjects']     
@@ -126,12 +132,14 @@ def getUiParams( torchpars, advtorchpars ):
   epochdrop = int(nrepochs*epochdroprate)
   if epochdrop < 1:
     epochdrop = 1
+  scale = getUiScaler(advtorchgrp['scalingfld'].active)
   transform = getUiTransforms(advtorchgrp)
   return getParams( epochs=torchgrp['epochfld'].value, \
                              batch=int(torchgrp['batchfld'].value), \
                              learnrate= 10**torchgrp['lrfld'].value, \
                              nntype=torchgrp['modeltypfld'].value, \
                              epochdrop=torchgrp['epochdrop'].value, \
+                             scale = scale,
                              transform=transform)
 
 def isSelected( fldwidget, index=0 ):
@@ -140,3 +148,4 @@ def isSelected( fldwidget, index=0 ):
 class uiTransform(Enum):
   RandomFlip = 0
   RandomGaussianNoise = 1
+  RandomRotation = 2


### PR DESCRIPTION
Added Random Rotation with a default angle of (15deg) which applies rotation between (-15 and 15 degrees)  on randomly selected samples.

Added new scaling methods to Pytorch  which include: 
- Global Normalization
- Local Normalization,
- Local Scaling and
-  MinMax Scaler

All the scaling methods except from Global Normalizing are done online for each image while training. It is applied after all data augmentation transforms, if any.  

Global Normalization is set as the default to `dgbpy.mlapply.getScaledTrainingData()` using the global mean and std of all the samples for standard scaling.

The Global Normalization method is applied to all workflows with Log output. `dgbpy.hdf5.isLogOutput()`

Information about the scaling method and its property is also saved to any trained model.

Increased the default number of Unet blocks in Pytorch from 1 to 2 so models can learn better.

Remove dict support for pytorch transforms. UI now uses default transform parameters available in `dgbpy.dgbtorch.torch_dict`.
