### PR TITLE
Fix UI Advanted Tab Transform and Scaling Options (Keras/Torch)

### DIFF
--- a/dgbpy/bokeh_apps/trainui/main.py
+++ b/dgbpy/bokeh_apps/trainui/main.py
@@ -20,6 +20,7 @@ from bokeh.models import CheckboxGroup
 from odpy.oscommand import (getPythonCommand, execCommand, kill,
                             isRunning, pauseProcess, resumeProcess)
 import dgbpy.keystr as dgbkeys
+import dgbpy.hdf5 as dgbhdf5
 from dgbpy import mlapply as dgbmlapply
 from dgbpy import uibokeh, uisklearn, uitorch, uikeras
 from dgbpy import mlio as dgbmlio
@@ -182,7 +183,7 @@ def training_app(doc):
     advparsgroups = (kerasadvpars, torchadvpars, None)
     keraspars['uiobjects']['dodecimatefld'].active = []
     keraspars['uiobjects']['sizefld'].text = uikeras.getSizeStr(info[dgbkeys.estimatedsizedictstr])
-    if new==uikeras.getPlatformNm(True)[0] or new==uitorch.getPlatformNm(True)[0]:
+    if new==uikeras.getPlatformNm(True)[0] or (new==uitorch.getPlatformNm(True)[0] and not dgbhdf5.isLogOutput(uitorch.info)):
       adparameterspanel.disabled = False
     else:
       adparameterspanel.disabled = True

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -87,6 +87,8 @@ def getUiPars(uipars=None):
   return uipars
 
 def getAdvancedUiPars(uipars=None):
+  if dgbhdf5.isLogOutput(info):
+    return {'grp':None, 'uiobjects':None}
   dict = torch_dict
   uiobjs={}
   if not uipars:
@@ -104,10 +106,11 @@ def getAdvancedUiPars(uipars=None):
   else:
     uiobjs = uipars['uiobjects']
 
-  setDefaultTransforms = []
-  for transform in dict['transform']:
-    setDefaultTransforms.append(uiTransform[transform].value)
-  uiobjs['augmentfld'].active = setDefaultTransforms
+  if uiobjs:
+    setDefaultTransforms = []
+    for transform in dict['transform']:
+      setDefaultTransforms.append(uiTransform[transform].value)
+    uiobjs['augmentfld'].active = setDefaultTransforms
   return uipars     
 
 def enableAugmentationCB(args, widget=None):
@@ -115,13 +118,18 @@ def enableAugmentationCB(args, widget=None):
 
 def getUiTransforms(advtorchgrp):
   transforms = []
+  if not advtorchgrp:
+    return transforms
   selectedkeys = advtorchgrp['augmentfld'].active
   for key in selectedkeys:
     transforms.append(uiTransform(key).name)
   return transforms
 
-def getUiScaler(selectedOption):
+def getUiScaler(advtorchgrp):
   scalers = (dgbkeys.globalstdtypestr, dgbkeys.localstdtypestr, dgbkeys.normalizetypestr, dgbkeys.minmaxtypestr)
+  if not advtorchgrp:
+    return scalers[0]
+  selectedOption = advtorchgrp['scalingfld'].active
   return scalers[selectedOption]
 
 def getUiParams( torchpars, advtorchpars ):
@@ -132,7 +140,7 @@ def getUiParams( torchpars, advtorchpars ):
   epochdrop = int(nrepochs*epochdroprate)
   if epochdrop < 1:
     epochdrop = 1
-  scale = getUiScaler(advtorchgrp['scalingfld'].active)
+  scale = getUiScaler(advtorchgrp)
   transform = getUiTransforms(advtorchgrp)
   return getParams( epochs=torchgrp['epochfld'].value, \
                              batch=int(torchgrp['batchfld'].value), \


### PR DESCRIPTION
- Disable advanced tab for log workflows with torch since there are no widgets to be displayed for log workflows.
- Ensure advanced tab only show tensorboard widgets during log workflows for keras.

Fix for the widgets made available to users for transforming the data. This includes:
- removing the current available data augmentation methods during log output workflows,
- removing local scaling methods for log output workflows.