### PR TITLE
Fixes for Earlystopping in Torch and Batch_size key in Torch_dict

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -278,6 +278,7 @@ def train(model, imgdp, params, cbfn=None, logdir = None, silent=False):
         validation_DataLoader=testloader,
         tensorboard=tensorboard,
         epochs=params['epochs'],
+        earlystopping = params['epochdrop'],
         imgdp=imgdp,
         silent = silent
     )

--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -42,7 +42,7 @@ torch_dict = {
     'epochs': 15,
     'epochdrop': 5,
     'criterion': nn.CrossEntropyLoss() if hasTorch() else None,
-    'batch_size': 8,
+    'batch': 8,
     'learnrate': 0.0001,
     'type': None,
     'prefercpu': None,
@@ -78,7 +78,7 @@ def getParams(
     learnrate=torch_dict['learnrate'],
     epochs=torch_dict['epochs'],
     epochdrop=torch_dict['epochdrop'],
-    batch=torch_dict['batch_size'],
+    batch=torch_dict['batch'],
     prefercpu = torch_dict['prefercpu'],
     scale=torch_dict['scale'],
     transform=torch_dict['transform'],
@@ -221,7 +221,7 @@ def onnx_from_torch(model, infos):
     from dgbpy.torch_classes import UNet
     model_instance = UNet(out_channels=nroutputs, dim=dims, in_channels=attribs)
   model_instance.load_state_dict(model.state_dict())
-  input_size = torch_dict['batch_size']
+  input_size = torch_dict['batch']
   if model.__class__.__name__ == 'UNet':
     input_size = 1
   if dims  == 3:
@@ -302,7 +302,7 @@ def apply( model, info, samples, scaler, isclassification, withpred, withprobs, 
       drop_last = True
   else:
     drop_last = False
-  batch_size = torch_dict['batch_size']
+  batch_size = torch_dict['batch']
   dataloader = getDataLoader(sampleDataset, batch_size=batch_size, drop_last=drop_last)
   if isclassification:
     nroutputs = len(info[dgbkeys.classesdictstr])
@@ -407,16 +407,16 @@ def apply( model, info, samples, scaler, isclassification, withpred, withprobs, 
         ret[dgbkeys.preddictstr] = ret[dgbkeys.preddictstr].transpose(3, 2, 1, 0)  
   return ret
 
-def getTrainTestDataLoaders(traindataset, testdataset, batchsize=torch_dict['batch_size']):
+def getTrainTestDataLoaders(traindataset, testdataset, batchsize=torch_dict['batch']):
     trainloader = DataLoader(dataset=traindataset, batch_size=batchsize, shuffle=True, drop_last=True)
     testloader= DataLoader(dataset=testdataset, batch_size=batchsize, shuffle=False, drop_last=True)
     return trainloader, testloader
 
-def getDataLoader(dataset, batch_size=torch_dict['batch_size'], drop_last=False):
+def getDataLoader(dataset, batch_size=torch_dict['batch'], drop_last=False):
     dataloader = DataLoader(dataset=dataset, batch_size=batch_size, shuffle=False, drop_last=drop_last)
     return dataloader
 
-def getDataLoaders(traindataset, testdataset, batchsize=torch_dict['batch_size']):
+def getDataLoaders(traindataset, testdataset, batchsize=torch_dict['batch']):
     trainloader = DataLoader(dataset=traindataset, batch_size=batchsize, shuffle=True, drop_last=True)
     testloader= DataLoader(dataset=testdataset, batch_size=batchsize, shuffle=False, drop_last=True)
     return trainloader, testloader

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -340,7 +340,7 @@ class ProgressBarCallback(Callback):
 
 class EarlyStoppingCallback(Callback):
     _order = 3
-    def __init__(self, patience = 5):
+    def __init__(self, patience):
         self.best = 0
         self.patience = patience
         self.patience_cnt = 0
@@ -392,6 +392,7 @@ class Trainer:
                  validation_DataLoader: torch.utils.data.Dataset = None,
                  tensorboard = None,
                  epochs: int = 100,
+                 earlystopping: int = 5,
                  imgdp = None,
                  cbs = None,
                  silent = None
@@ -410,7 +411,7 @@ class Trainer:
 
         self.cbs = []
         defaultCBS = [ TrainEvalCallback(), AvgStatsCallback(metrics),
-                        EarlyStoppingCallback(), TensorBoardLogCallback()]
+                        EarlyStoppingCallback(earlystopping), TensorBoardLogCallback()]
         if not hasFastprogress(): self.silent = True
         if not self.silent: defaultCBS.append(ProgressBarCallback())
         self.add_cbs(defaultCBS)

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -55,7 +55,7 @@ def getUiPars(uipars=None):
               }
             }
 
-  defbatchsz = torch_dict['batch_size']
+  defbatchsz = torch_dict['batch']
   defmodel = modeltypes[0]
   estimatedsz = info[dgbkeys.estimatedsizedictstr]
   if tc.TorchUserModel.isImg2Img( defmodel ):


### PR DESCRIPTION
**Summary**
- Make Earlystopping in UI work with the Earlystopping Callback in Pytorch Trainer
- Change `batch_size` in torch_dict to `batch`. (Similar to keras)