### PR TITLE
Mixed Precision Implementation for dgbtorch

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -50,7 +50,8 @@ torch_dict = {
     'prefercpu': None,
     'scale': dgbkeys.globalstdtypestr,
     'transform':default_transforms,
-    'withtensorboard': withtensorboard
+    'withtensorboard': withtensorboard,
+    'tofp16': True,
 }
 
 def getMLPlatform():
@@ -88,7 +89,8 @@ def getParams(
     nbfold=torch_dict['nbfold'],
     scale=torch_dict['scale'],
     transform=torch_dict['transform'],
-    withtensorboard=torch_dict['withtensorboard']):
+    withtensorboard=torch_dict['withtensorboard'],
+    tofp16=torch_dict['tofp16']):
   ret = {
     dgbkeys.decimkeystr: dodec,
     'type': nntype,
@@ -101,7 +103,8 @@ def getParams(
     'batch': batch,
     'scale': scale,
     'transform': transform,
-    'withtensorboard': withtensorboard
+    'withtensorboard': withtensorboard,
+    'tofp16': tofp16,
   }
   if prefercpu == None:
     prefercpu = not can_use_gpu()
@@ -269,7 +272,7 @@ def save( model, outfnm, infos, save_type=defsavetype ):
     modelgrp.create_dataset('object',data=exported_model)
   h5file.close()
 
-def train(model, imgdp, params, cbfn=None, logdir = None, silent=False):
+def train(model, imgdp, params, cbfn=None, logdir=None, silent=False):
     from dgbpy.torch_classes import Trainer
     trainloader, testloader = DataGenerator(imgdp,batchsize=params['batch'],scaler=params['scale'],transform=params['transform'])
     criterion = torch_dict['criterion']
@@ -292,7 +295,8 @@ def train(model, imgdp, params, cbfn=None, logdir = None, silent=False):
         epochs=params['epochs'],
         earlystopping = params['epochdrop'],
         imgdp=imgdp,
-        silent = silent
+        silent = silent,
+        tofp16=params['tofp16']
     )
     model = trainer.fit(cbs = cbfn)
     return model

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -125,6 +125,7 @@ def getAdvancedUiPars(uipars=None):
   uiobjs={}
   if not uipars:
     uiobjs = {
+      'tofp16fld': CheckboxGroup(labels=['Use Mixed Precision'], visible=can_use_gpu(), margin=(5, 5, 0, 5)),
       'tensorboardfld': CheckboxGroup(labels=['Enable Tensorboard'], visible=True, margin=(5, 5, 0, 5)),
       'cleartensorboardfld': CheckboxGroup(labels=['Clear Tensorboard log files'], visible=True, margin=(5, 5, 0, 5))
     }
@@ -144,6 +145,7 @@ def getAdvancedUiPars(uipars=None):
   else:
     uiobjs = uipars['uiobjects']
 
+  uiobjs['tofp16fld'].active = [] if not dict['tofp16'] else [0]
   uiobjs['tensorboardfld'].active = [] if not dict['withtensorboard'] else [0]
   uiobjs['cleartensorboardfld'].active = []
   return uipars     
@@ -185,6 +187,7 @@ def getUiParams( torchpars, advtorchpars ):
   scale = getUiScaler(advtorchgrp)
   transform = getUiTransforms(advtorchgrp)
   withtensorboard = True if len(advtorchgrp['tensorboardfld'].active)!=0 else False
+  tofp16 = True if len(advtorchgrp['tofp16fld'].active)!=0 else False
   return getParams( dodec=isSelected(torchgrp['dodecimatefld']), \
                              nbchunk = torchgrp['chunkfld'].value, \
                              epochs=torchgrp['epochfld'].value, \
@@ -197,7 +200,8 @@ def getUiParams( torchpars, advtorchpars ):
                              prefercpu = runoncpu,
                              scale = scale,
                              transform=transform,
-                             withtensorboard = withtensorboard)
+                             withtensorboard = withtensorboard,
+                             tofp16 = tofp16,)
 
 def isSelected( fldwidget, index=0 ):
   return uibokeh.integerListContains( fldwidget.active, index )


### PR DESCRIPTION
Mixed precision uses lower precision data types, such as float16 or bfloat16, to speed up the convergence of deep learning models while also reducing memory usage.

- This technique is allowed by default.
- To switch it off, simply set the key parameter in torch_dict to False.
```python 
dgbtorch.torch_dict['tofp16'] = False
```
- This is now also available for use in the bokeh torch platform if the user has a CUDA-Enabled GPU.