### PR TITLE
Update bokeh to version 3

### DIFF
--- a/dgbpy/bokehcore.py
+++ b/dgbpy/bokehcore.py
@@ -1,0 +1,66 @@
+import bokeh
+from bokeh.core import enums
+from bokeh.plotting import figure
+from bokeh.io import curdoc
+from bokeh.models import Spacer, ColumnDataSource, Range1d, Spinner
+
+version = bokeh.__version__
+
+def is_version_3():
+    return version.startswith('3')
+
+if is_version_3():
+    from bokeh.models import TabPanel
+    from bokeh.models import Select, Tabs, CheckboxGroup, Slider, RadioGroup, Button
+else:
+    from bokeh.models.widgets import Panel as TabPanel
+    from bokeh.models.widgets import Select, Tabs, CheckboxGroup, Slider, RadioGroup, Button
+    from bokeh.plotting import curdoc
+
+def add_property(widget, name, value):
+    if is_version_3():
+        setattr(widget, name, value)
+    else:
+        setattr(widget, name, value)
+    
+def column(*args, **kwargs):
+    from bokeh.layouts import column
+    try:
+        return column(*args, **kwargs)
+    except ValueError:
+        args = [arg() if callable(arg) else arg for arg in args]
+        kwargs = {k: v() if callable(v) else v for k, v in kwargs.items()}
+        return column(*args, **kwargs)
+    
+def row(*args, **kwargs):
+    from bokeh.layouts import row
+    try:
+        return row(*args, **kwargs)
+    except ValueError:
+        args = [arg() if callable(arg) else arg for arg in args]
+        kwargs = {k: v() if callable(v) else v for k, v in kwargs.items()}
+        return row(*args, **kwargs)
+    
+    
+
+class Div:
+    def __init__(self, text='', **kwargs):
+        self.isV3 = is_version_3() 
+        if self.isV3:
+            from bokeh.models import Div
+            self.widget = Div( text=text, **kwargs)
+        else:
+            from bokeh.models.widgets import Div
+            self.widget = Div( text=text, **kwargs)
+
+    def __setattr__(self, name, value):
+        try: 
+            if name == 'styles' and not self.isV3:
+                setattr(self.widget, 'style', value)
+            else:
+                setattr(self.widget, name, value)
+        except:
+            super().__setattr__(name, value)
+
+    def __call__(self):
+        return self.widget

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -1303,7 +1303,6 @@ class SeismicTestDataset(Dataset):
 
 class DatasetApply(Dataset):
     def __init__(self, X, info, isclassification, im_ch, ndims):
-        from dgbpy import transforms as T
         super().__init__()
         self.im_ch = im_ch
         self.ndims = ndims

--- a/dgbpy/uibokeh.py
+++ b/dgbpy/uibokeh.py
@@ -10,11 +10,7 @@ from enum import Enum
 from functools import partial
 import re
 
-from bokeh.core import enums
-from bokeh.layouts import row, column
-from bokeh.models import Spacer, ColumnDataSource, Range1d, Div
-from bokeh.models.widgets import Button
-from bokeh.plotting import curdoc, figure
+from dgbpy.bokehcore import *
 
 import dgbpy.keystr as dgbkeys
 import dgbpy.hdf5 as dgbhdf5
@@ -52,12 +48,12 @@ class TrainStatusUI():
     self.message.visible = True
     if status==TrainStatus.Success:
       self.message.text = '✅ Training Successful'
-      self.message.style = { "color":"#139D41", "background-color": "white", "font-size": "16px",
+      self.message.styles = { "color":"#139D41", "background-color": "white", "font-size": "12px",
                             "border": "4px solid #0CB61E", "border-radius": "8px",
                             "box-shadow": "2px 2px 5px rgba(0, 0, 0, 0.5)", "padding": "5px 10px" }
     elif status==TrainStatus.Failed:
       self.message.text = '🚫 Training Failed'
-      self.message.style = { "color": "red", "background-color": "white", "font-size": "16px",
+      self.message.styles = { "color": "red", "background-color": "white", "font-size": "12px",
                             "border": "4px solid red", "border-radius": "8px", 
                             "box-shadow": "2px 2px 5px rgba(0, 0, 0, 0.5)", "padding": "5px 10px" } 
 
@@ -95,7 +91,7 @@ def getRunButtonsBar(progress,runact,abortact,pauseact,resumeact,progressact,tim
   pauseresumebut = getPauseResumeButton()
   pauseresumebut.visible = False
   buttonsgrp = row(pauseresumebut,Spacer(width=but_spacer),runstopbut,width_policy='min')
-  buttonsfld = row(Spacer(width=but_spacer),buttonsgrp, sizing_mode='stretch_width')
+  buttonsfld = row(Spacer(width=but_spacer),buttonsgrp, sizing_mode='stretch_width', align='end')
   ret = {
     'run': runstopbut,
     'pause': pauseresumebut,

--- a/dgbpy/uikeras.py
+++ b/dgbpy/uikeras.py
@@ -11,8 +11,7 @@ from functools import partial
 import numpy as np
 from enum import Enum
 
-from bokeh.layouts import column
-from bokeh.models.widgets import CheckboxGroup, Div, Select, Slider, RadioGroup
+from dgbpy.bokehcore import *
 
 from odpy.common import log_msg
 from dgbpy.dgbkeras import *
@@ -71,10 +70,10 @@ def getUiPars(uipars=None):
   uiobjs = {}
   if not uipars:
     uiobjs = {
-      'modeltypfld': Select(title='Type', options=modeltypes),
+      'modeltypfld': Select(title='Type', options=modeltypes, width=300),
       'validfld' : validfld,
       'foldfld' : Slider(start=1,end=5,title='Number of fold(s)',visible=isCrossVal),
-      'batchfld': Select(title='Batch Size',options=cudacores),
+      'batchfld': Select(title='Batch Size',options=cudacores, width=300),
       'epochfld': Slider(start=1,end=1000, title='Epochs'),
       'patiencefld': Slider(start=1,end=100, title='Patience'),
       'lrfld': Slider(start=-10,end=-1,step=1, title='Initial Learning Rate (1e)'),
@@ -86,7 +85,7 @@ def getUiPars(uipars=None):
     }
     if estimatedsz:
       uiobjs['sizefld'] = Div( text=getSizeStr( estimatedsz ) )
-    uiobjs['dodecimatefld'].on_click(partial(decimateCB,chunkfld=uiobjs['chunkfld'],sizefld=uiobjs['sizefld']))
+    uiobjs['dodecimatefld'].on_change('active', partial(decimateCB, uiobjs['chunkfld'], uiobjs['sizefld']))
     try:
       uiobjs['chunkfld'].on_change('value_throttled',partial(chunkfldCB, uiobjs['sizefld']))
     except AttributeError:
@@ -109,7 +108,7 @@ def getUiPars(uipars=None):
   uiobjs['dodecimatefld'].active = []
   uiobjs['chunkfld'].value = dict['nbchunk']
   uiobjs['rundevicefld'].active = [0]
-  decimateCB( uiobjs['dodecimatefld'].active,uiobjs['chunkfld'],uiobjs['sizefld'] )
+  decimateCB( uiobjs['chunkfld'],uiobjs['sizefld'], None, None ,uiobjs['dodecimatefld'].active )
   return uipars
 
 def getAdvancedUiPars(uipars=None):
@@ -199,8 +198,8 @@ def getUiParams( keraspars, advkeraspars ):
 def isSelected( fldwidget, index=0 ):
   return uibokeh.integerListContains( fldwidget.active, index )
 
-def decimateCB( widgetactivelist,chunkfld,sizefld ):
-  decimate = uibokeh.integerListContains( widgetactivelist, 0 )
+def decimateCB(chunkfld,sizefld,attr,old,new):
+  decimate = uibokeh.integerListContains( new, 0 )
   chunkfld.visible = decimate
   size = info[dgbkeys.estimatedsizedictstr]
   if sizefld and size:

--- a/dgbpy/uisklearn.py
+++ b/dgbpy/uisklearn.py
@@ -8,10 +8,7 @@
 
 from functools import partial
 
-from bokeh.core import enums
-from bokeh.layouts import row, column
-from bokeh.models import Spacer
-from bokeh.models.widgets import Button, Select, Slider, Spinner, Div
+from dgbpy.bokehcore import *
 
 from odpy.common import log_msg
 from dgbpy.dgbscikit import *

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -4,7 +4,7 @@ import numpy as np
 from enum import Enum
 
 from bokeh.layouts import column
-from bokeh.models.widgets import CheckboxGroup, Div, Select, Slider, RadioGroup
+from dgbpy.bokehcore import *
 
 from odpy.common import log_msg
 from dgbpy.transforms import hasOpenCV
@@ -33,8 +33,8 @@ def chunkfldCB(sizefld,attr,old,new):
   if sizefld and size:
     sizefld.text = getSizeStr( size/new )
 
-def decimateCB( widgetactivelist,chunkfld,sizefld ):
-  decimate = uibokeh.integerListContains( widgetactivelist, 0 )
+def decimateCB(chunkfld,sizefld,attr,old,new):
+  decimate = uibokeh.integerListContains( new, 0 )
   chunkfld.visible = decimate
   size = info[dgbkeys.estimatedsizedictstr]
   if sizefld and size:
@@ -81,10 +81,10 @@ def getUiPars(uipars=None):
   uiobjs = {}
   if not uipars:
     uiobjs = {
-      'modeltypfld': Select(title='Type', options=modeltypes),
+      'modeltypfld': Select(title='Type', options=modeltypes, width=300),
       'validfld': validfld,
       'foldfld' : Slider(start=1,end=5,title='Number of fold(s)',visible=isCrossVal),
-      'batchfld': Select(title='Batch Size', options=cudacores),
+      'batchfld': Select(title='Batch Size', options=cudacores, width=300),
       'epochfld': Slider(start=1, end=1000, title='Epochs'),
       'epochdrop': Slider(start=1, end=100, title='Early Stopping'),
       'lrfld': Slider(start=-10,end=-1,step=1, title='Initial Learning Rate (1e)'),
@@ -95,7 +95,7 @@ def getUiPars(uipars=None):
     }
     if estimatedsz:
       uiobjs['sizefld'] = Div( text=getSizeStr( estimatedsz ) )
-    uiobjs['dodecimatefld'].on_click(partial(decimateCB,chunkfld=uiobjs['chunkfld'],sizefld=uiobjs['sizefld']))
+    uiobjs['dodecimatefld'].on_change('active', partial(decimateCB, uiobjs['chunkfld'], uiobjs['sizefld']))
     try:
       uiobjs['chunkfld'].on_change('value_throttled', partial(chunkfldCB, uiobjs['sizefld']))
     except AttributeError:
@@ -117,7 +117,7 @@ def getUiPars(uipars=None):
   uiobjs['dodecimatefld'].active = []
   uiobjs['chunkfld'].value = dict['nbchunk']
   uiobjs['rundevicefld'].active = [0]
-  decimateCB( uiobjs['dodecimatefld'].active, uiobjs['chunkfld'], uiobjs['sizefld'] )
+  decimateCB( uiobjs['chunkfld'],uiobjs['sizefld'], None,None,uiobjs['dodecimatefld'].active )
   return uipars
 
 def getAdvancedUiPars(uipars=None):


### PR DESCRIPTION
- A new **`bokehcore.py`** file was added to import the widgets from the right path depending on the version available

-  Removed previous callback mechanism for platform change in both version 3 and 2. The platform change callback now update all other tabs/panels without clearing the whole document and reloading them back.

- Removed checkboxgroup  previous `on_click()` callback as its no longer available in version 3. This has been updated to the normal `on_change()` callback mechanism for both version 2 and 3.

- **Panel** widget is now called **TabPanel** and `bokehcore.py` handles proper import.

- Implement compatible widgets for both v2 and v3 for `Div` and made `Column `and `Row `layouts compatible with this change.

- Ensured the syntax used in the main codebase were of bokeh version 3.0 or greater. This will allow us to easily drop support for older versions later by simply removing the custom widget classes in the `bokehcore.py` file.

- This update is still for the training app alone.