### PR TITLE
Fix numpy core issue in getCubeLetNames

### DIFF
--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -52,6 +52,7 @@ def getCubeLetNamesByGroupByItem( info, groupnm, collnm, idx ):
   if collnm in dsetnms:
     ret = np.arange(len(group[collnm][xdatadictstr]))
   else:
+    dsetnms = list(map(str, dsetnms))
     dsetwithinp = np.chararray.startswith( dsetnms, str(idx)+':' )
     ret = np.extract( dsetwithinp, dsetnms )
   h5file.close()


### PR DESCRIPTION
`np.chararray.startswith( dsetnms, str(idx)+':' )` returns `TypeError` when `dsetnms` is a non-string array in `getCubeLetNamesByGroupByItem`