### PR TITLE
Torch Unet architecture

### DIFF
--- a/dgbpy/mlmodel_torch_dGB.py
+++ b/dgbpy/mlmodel_torch_dGB.py
@@ -21,7 +21,7 @@ class dGB_UnetSeg(TorchUserModel):
     model = UNet(in_channels=nrattribs, n_blocks=1, out_channels=nroutputs, dim=ndim)
     return model
 
-from dgbpy.torch_classes import Net, create_resnet_block, UNet, dGBLeNet, UNet_VGG19
+from dgbpy.torch_classes import Net, create_resnet_block, UNet, dGBLeNet, UNet_VGG19, dGBUNet
 import torch.nn as nn
 
 class dGB_Simple_Net_Classifier(TorchUserModel):
@@ -47,7 +47,7 @@ class dGB_UnetReg(TorchUserModel):
   def _make_model(self, model_shape, nroutputs, nrattribs):
     from dgbpy.dgbtorch import getModelDims
     ndim = getModelDims(model_shape, 'channels_first')
-    model = UNet(in_channels=nrattribs, n_blocks=1, out_channels=nroutputs, dim=ndim)
+    model = dGBUNet(nrattribs, model_shape, nroutputs, self.predtype)
     return model
 
 class dGB_ResNet18(TorchUserModel):

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -1092,7 +1092,6 @@ class dGBUNet(nn.Module):
         upconv3 = self.upconv3(concat3)
 
         final_conv = self.final_conv(upconv3)
-        # output = self.activation(final_conv)
         return final_conv
 
 class UNet(nn.Module):


### PR DESCRIPTION
 This PR replicates a similar unet architecture from dgbkeras in dgbtorch.
 - This architecture ensures each downblock or upblock in the unet contains two convolutions layer rather than one in the previous implementation.
 - This change is also mostly targeted at Image regression task