### PR TITLE
Fix training type selection in bokeh trainui

### DIFF
--- a/dgbpy/bokeh_apps/trainui/main.py
+++ b/dgbpy/bokeh_apps/trainui/main.py
@@ -85,7 +85,6 @@ def training_app(doc):
           trainingpars['Input Model File'] = val
         else:
           trainingpars['Input Model File'] = None
-          trainingpars['Training Type'] = dgbmlapply.TrainType.New
       elif key=='ProcLog File':
         odcommon.log_msg(f'Change log file name to "{val}".')
         trainingpars['Proc Log File'] = val


### PR DESCRIPTION
This PR fixes the issue with custom model architectures changing to a default one which is caused by the wrong TrainType value which is passed to `mlapply.doTrain`. This is because every single time a new input model file is set to an empty file, the TrainType value is set to `New`