### PR TITLE
Load platform compute info on server startup

### DIFF
--- a/dgbpy/bokeh_apps/trainui/app_hooks.py
+++ b/dgbpy/bokeh_apps/trainui/app_hooks.py
@@ -6,10 +6,14 @@ def on_server_loaded(server_context):
         pass
     try:
         import torch
+        from dgbpy.dgbtorch import get_torch_infos
+        get_torch_infos()
     except ModuleNotFoundError:
         pass
     try:
         import tensorflow
+        from dgbpy.dgbkeras import get_keras_infos
+        get_keras_infos()
     except ModuleNotFoundError:
         pass
         

--- a/dgbpy/bokeh_apps/trainui/main.py
+++ b/dgbpy/bokeh_apps/trainui/main.py
@@ -65,6 +65,14 @@ def training_app(doc):
     uitorch.info = info
     uisklearn.info = info
 
+  def getPlatformInfo( platform ):
+      if platform==dgbkeys.torchplfnm:
+        from dgbpy.dgbtorch import get_torch_infos
+        return get_torch_infos()
+      elif platform==dgbkeys.kerasplfnm:
+        from dgbpy.dgbkeras import get_keras_infos
+        return get_keras_infos()
+
   def trainingParChgCB( paramobj ):
     nonlocal trainingpars
     nonlocal info
@@ -520,6 +528,7 @@ def training_app(doc):
   if args:
     this_service = ServiceMgr(args['bsmserver'],args['port'],get_request_id())
     this_service.addAction('BokehParChg', trainingParChgCB )
+    this_service.addAction('GetInfos', getPlatformInfo)
     mh = MsgHandler()
     mh.add_servmgr(this_service)
     mh.add('--Training Started--', 'bokeh_app_msg', {'training_started': ''})

--- a/dgbpy/dgbkeras.py
+++ b/dgbpy/dgbkeras.py
@@ -58,6 +58,8 @@ def getUIMLPlatform():
 
 defbatchstr = 'defaultbatchsz'
 
+keras_infos = None
+
 default_transforms = []
 keras_dict = {
   dgbkeys.decimkeystr: False,
@@ -86,13 +88,17 @@ def get_cpu_preference():
   return len(tfconfig.list_physical_devices('GPU')) < 1
 
 def get_keras_infos():
+  global keras_infos
+  if keras_infos:
+    return keras_infos
   ret = {
     'haskerasgpu': can_use_gpu(),
     dgbkeys.prefercpustr: get_cpu_preference(),
     'batchsizes': cudacores,
     defbatchstr: keras_dict['batch']
    }
-  return json.dumps( ret )
+  keras_infos = json.dumps( ret )
+  return keras_infos
 
 def set_compute_device( prefercpu ):
   if not prefercpu:

--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -38,6 +38,8 @@ default_transforms = []
 
 defbatchstr = 'defaultbatchsz'
 
+torch_infos = None
+
 torch_dict = {
     dgbkeys.decimkeystr: False,
     'nbchunk': 10,
@@ -80,13 +82,17 @@ def set_compute_device(prefercpu):
   device = torch.device('cuda:0' if not prefercpu else 'cpu')
 
 def get_torch_infos():
+  global torch_infos
+  if torch_infos:
+    return torch_infos
   ret = {
     'hastorchgpu': can_use_gpu(),
     dgbkeys.prefercpustr: not can_use_gpu(),
     'batchsizes': cudacores,
     defbatchstr: torch_dict['batch']
   }
-  return json.dumps( ret )
+  torch_infos = json.dumps( ret )
+  return torch_infos
 
 def getParams( 
     nntype=torch_dict['type'],

--- a/dgbpy/servicemgr.py
+++ b/dgbpy/servicemgr.py
@@ -81,7 +81,7 @@ class ServiceMgr(tornado.tcpserver.TCPServer):
           port += 1
         else:
           raise ex
-    raise Exception("Failed to find available port");
+    raise Exception("Failed to find available port")
 
   def _register(self, port, address):
     odcommon.std_msg( 'Registering with port', port, 'and address', address )


### PR DESCRIPTION
- This PR includes a new action to the servicemgr for the bokeh machine learning app that allows to fetch available compute device details for both torch and keras.