### PR TITLE
Pytorch Fixes

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -302,7 +302,7 @@ def save( model, outfnm, infos, save_type=defsavetype ):
 def train(model, imgdp, params, cbfn=None, logdir=None, silent=False):
     from dgbpy.torch_classes import Trainer, AdaptiveLR
     trainloader, testloader = DataGenerator(imgdp,batchsize=params['batch'],scaler=params['scale'],transform=params['transform'])
-    criterion = torch_dict['criterion']
+    criterion = params['criterion']
     if imgdp[dgbkeys.infodictstr][dgbkeys.classdictstr]==False:
       criterion = nn.MSELoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=params['learnrate'])

--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -214,9 +214,10 @@ def load( modelfnm ):
   modelgrp = h5file['model']
   savetype = odhdf5.getText( modelgrp, 'type' )
   
-  modeltype = odhdf5.getText(h5file, 'type')
-  if modeltype=='Sequential' or modeltype=='Net':
-    savetype = savetypes[1]
+  if odhdf5.hasAttr( h5file, 'type' ):
+    modeltype = odhdf5.getText(h5file, 'type')
+    if modeltype=='Sequential' or modeltype=='Net':
+      savetype = savetypes[1]
   if savetype == savetypes[0]:
     modfnm = odhdf5.getText( modelgrp, 'path' )
     modfnm = dgbhdf5.translateFnm( modfnm, modelfnm )


### PR DESCRIPTION
This PR ensures:
- dgbtorch.train uses the critertion specified in  its input parameter `params` for training
- ensure dgbtorch.load doesn't depend too much on some attributes (useful for loading the faultnet model)