### PR TITLE
Add custom metric for dgbtorch

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -305,7 +305,7 @@ def save( model, outfnm, infos, save_type=defsavetype ):
     modelgrp.create_dataset('object',data=exported_model)
   h5file.close()
 
-def train(model, imgdp, params, cbfn=None, logdir=None, silent=False):
+def train(model, imgdp, params, cbfn=None, logdir=None, silent=False, metrics=False):
     from dgbpy.torch_classes import Trainer, AdaptiveLR
     trainloader, testloader = DataGenerator(imgdp,batchsize=params['batch'],scaler=params['scale'],transform=params['transform'])
     criterion = params['criterion']
@@ -329,6 +329,7 @@ def train(model, imgdp, params, cbfn=None, logdir=None, silent=False):
         device = device,
         training_DataLoader=trainloader,
         validation_DataLoader=testloader,
+        metrics=metrics,
         tensorboard=tensorboard,
         epochs=params['epochs'],
         earlystopping = params['patience'],

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -539,7 +539,7 @@ class Trainer:
         if dgbhdf5.isImg2Img(self.info): self.metrics.append(jaccard)
         else: self.metrics = [mae]
 
-        custom_metrics = dgbkeys.listify(custom_metrics)
+        custom_metrics = dgbkeys.listify(custom_metrics if custom_metrics else [])
         for metric in custom_metrics:
             if not callable(metric): raise TypeError("custom metric must be a valid function")
             self.metrics.append(metric)

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -498,6 +498,7 @@ class Trainer:
                  device: torch.device,
                  training_DataLoader: torch.utils.data.Dataset,
                  validation_DataLoader: torch.utils.data.Dataset = None,
+                 metrics = None,
                  tensorboard = None,
                  epochs: int = 100,
                  earlystopping: int = 5,
@@ -513,11 +514,8 @@ class Trainer:
         self.tensorboard, self.silent, self.earlystopping = tensorboard, silent, earlystopping
         self.scheduler = scheduler
 
-        info = self.imgdp[dgbkeys.infodictstr]
-        self.classification = dgbhdf5.isClassification(info)
-        if self.classification: self.metrics = [accuracy, f1]
-        if dgbhdf5.isImg2Img(info): self.metrics.append(jaccard)
-        else: self.metrics = [mae]
+        self.info = self.imgdp[dgbkeys.infodictstr]
+        self.set_metrics(metrics)
             
         self.tofp16 = tofp16 and torch.cuda.is_available()
         self.gradScaler = torch.cuda.amp.GradScaler() if self.tofp16 else None
@@ -532,6 +530,19 @@ class Trainer:
         if hasFastprogress() and not self.silent: defaultCBS.append(ProgressBarCallback())
         self.add_cbs(defaultCBS)
         self.add_cbs(cbs)
+
+    def set_metrics(self, custom_metrics):
+        custom_metrics = dgbkeys.listify(custom_metrics)
+        self.classification = dgbhdf5.isClassification(self.info)
+
+        if self.classification: self.metrics = [accuracy, f1]
+        if dgbhdf5.isImg2Img(self.info): self.metrics.append(jaccard)
+        else: self.metrics = [mae]
+
+        custom_metrics = dgbkeys.listify(custom_metrics)
+        for metric in custom_metrics:
+            if not callable(metric): raise TypeError("custom metric must be a valid function")
+            self.metrics.append(metric)
 
     def add_cbs(self, cbs):
         for cb in dgbkeys.listify(cbs):

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -532,7 +532,6 @@ class Trainer:
         self.add_cbs(cbs)
 
     def set_metrics(self, custom_metrics):
-        custom_metrics = dgbkeys.listify(custom_metrics)
         self.classification = dgbhdf5.isClassification(self.info)
 
         if self.classification: self.metrics = [accuracy, f1]


### PR DESCRIPTION
This PR allows users to include a custom metric in the training function

```python
import dgbpy.dgbtorch as dgbtorch

def new_metric(pred, target):
       m = #custom metric
       return m

dgbtorch.train(model, data, params, metrics = [new_metric])
```
This metric will be included in the train log table for both training and validation