### PR TITLE
Fix keras mixed precision compatibility check

### DIFF
--- a/dgbpy/dgbkeras.py
+++ b/dgbpy/dgbkeras.py
@@ -1034,6 +1034,8 @@ def is_gpu_ready():
 
 def is_mixed_precision_compatible(min_version=(7,0)):
   devs = getDevicesInfo()
+  if len(devs) < 1:
+    return False
   return compute_capability_from_device_desc(devs[0]) >= min_version if devs else False
 
 def need_channels_last():


### PR DESCRIPTION
This PR fixes the issue with the `is_mixed_precision_compatible` function in `dgbpy.dgbkeras`. This fix ensures that when no gpu device is found, this function still works as expected.