### PR TITLE
Use one variable for withunlabeled string

### DIFF
--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -448,8 +448,8 @@ def getInfo( filenm, quick ):
   logoutp = isLogOutput(learntype)
 
   hasunlabels = False
-  if odhdf5.hasAttr(info, withunlabeledstr):
-    hasunlabels = odhdf5.getBoolValue( info, withunlabeledstr )
+  if odhdf5.hasAttr(info, withunlabeleddictstr):
+    hasunlabels = odhdf5.getBoolValue( info, withunlabeleddictstr )
 
   arrayorder = carrorderstr
   arrorderstr = 'Examples.ArrayOrder'

--- a/dgbpy/keystr.py
+++ b/dgbpy/keystr.py
@@ -110,7 +110,6 @@ torchplfnm = 'torch'
 typestr = 'Type'
 valuestr = 'Value'
 versionstr = 'Version'
-withunlabeledstr = 'Withunlabeled'
 
 # Others
 ndimstr = 'ndims'


### PR DESCRIPTION
This PR ensures one keystr variable is used throughout the application to represent the "withunlabeled" string