### PR TITLE
Allow string parameters for criterion in torch param

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -207,17 +207,17 @@ def getModelDims( model_shape, data_format ):
     return 0
   return len(ret)
 
-def get_criterion( imgdp, params ):
-    criterion = params['criterion']
-    if not criterion:
-      if dgbhdf5.isRegression(imgdp):
-        return nn.MSELoss()
-      return nn.CrossEntropyLoss()
-    if hasattr(nn, criterion):
-      return getattr(nn, criterion)()
-    if criterion in globals():
-      return globals()[criterion]()
-    raise ValueError('Unsupported loss function: %s' % criterion)
+  def get_criterion( imgdp, params ):
+      criterion = params['criterion']
+      if not criterion:
+        if dgbhdf5.isRegression(imgdp):
+          return nn.MSELoss()
+        return nn.CrossEntropyLoss()
+      if hasattr(nn, criterion):
+        return getattr(nn, criterion)()
+      if criterion in globals():
+        return globals()[criterion]()
+      raise ValueError('Unsupported loss function: %s' % criterion)
 
 savetypes = ( 'onnx', 'joblib', 'pickle' )
 defsavetype = savetypes[0]

--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -48,7 +48,7 @@ torch_dict = {
     'epochdrop': 5,
     'split': 0.2,
     'nbfold': 5,
-    'criterion': 'CrossEntropyLoss',
+    'criterion': None,
     'batch': 8,
     'learnrate': 1e-4,
     'type': None,

--- a/tests/test_dgbtorch.py
+++ b/tests/test_dgbtorch.py
@@ -84,7 +84,7 @@ def test_training_parameters():
         elif key in ['split', 'learnrate']:
             assert isinstance(value, (float, int))
         elif key in ['criterion']:
-            assert isinstance(value, (nn.modules.loss._Loss, nn.Module))
+            assert isinstance(value, str)
         elif key in ['scale']:
             assert isinstance(value, str)
         elif key in ['type']:


### PR DESCRIPTION
This PR ensures the torch dict parameter is totally serializable. It allows the torch_dict params to accept the loss value as a string. It initializes the criterion by fetching the class from `torch.nn` module. It also allows the use of custom defined loss in dgbtorch.py.

Acceptable strings:
- Loss class names defined in dgbtorch.py (e.g DiceLoss)
- Loss class names defined in torch.nn (e.g CrossEntropyLoss) - users are expected to use the pytorch class name as the parameter
- None, this initializes the right loss class by default