### PR TITLE
OD-5288 Support torch pt and pth models

### DIFF
--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -157,6 +157,12 @@ def isCrossValidation( info ):
       return getNrGroupInputs(info) > 1
   return False
 
+def isHDF5File( filenm ):
+  return Path(filenm).suffix == '.'+hdf5ext
+
+def isTorchModelFile( filenm ):
+  return Path(filenm).suffix == '.pt' or Path(filenm).suffix == '.pth'
+
 def unscaleOutput( info ):
   if isinstance(info,dict) and outputunscaledictstr in info:
     return info[outputunscaledictstr]

--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -157,12 +157,6 @@ def isCrossValidation( info ):
       return getNrGroupInputs(info) > 1
   return False
 
-def isHDF5File( filenm ):
-  return Path(filenm).suffix == '.'+hdf5ext
-
-def isTorchModelFile( filenm ):
-  return Path(filenm).suffix == '.pt' or Path(filenm).suffix == '.pth'
-
 def unscaleOutput( info ):
   if isinstance(info,dict) and outputunscaledictstr in info:
     return info[outputunscaledictstr]

--- a/dgbpy/mlapply.py
+++ b/dgbpy/mlapply.py
@@ -409,7 +409,7 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
     infos = trainingdp[dgbkeys.infodictstr]
     modtype = dgbmlio.getModelType( infos )
     outfnm = dgbmlio.getSaveLoc( outnm, modtype, args )
-    dgbmlio.saveModel( model, examplefilenm, platform, infos, outfnm )
+    dgbmlio.saveModel( model, examplefilenm, platform, infos, outfnm, params )
     return (outfnm != None and os.path.isfile( outfnm ))
   except Exception as e:
     dgbmlio.announceTrainingFailure()

--- a/dgbpy/mlio.py
+++ b/dgbpy/mlio.py
@@ -331,7 +331,7 @@ def unnormalize_class_vector( arr, classes ):
   for i in reversed(range( len(classes) ) ):
     arr[arr == i] = classes[i]
 
-def saveModel( model, inpfnm, platform, infos, outfnm ):
+def saveModel( model, inpfnm, platform, infos, outfnm, params ):
   """ Saves trained model for any platform workflow
 
   Parameters:
@@ -340,6 +340,7 @@ def saveModel( model, inpfnm, platform, infos, outfnm ):
     * platform (str): machine learning platform (options; keras, Scikit-learn, torch)
     * infos (dict): example file info
     * outfnm (str): name of model to be saved
+    * params (dict): parameters to be used when saving the model
   """
 
   from odpy.common import log_msg
@@ -359,7 +360,7 @@ def saveModel( model, inpfnm, platform, infos, outfnm ):
     dgbscikit.save( model, outfnm )
   elif platform == dgbkeys.torchplfnm or platform == dgbkeys.onnxplfnm:
     import dgbpy.dgbtorch as dgbtorch
-    dgbtorch.save( model, outfnm, infos )
+    dgbtorch.save( model, outfnm, infos, params )
   else:
     log_msg( 'Unsupported machine learning platform' )
     raise AttributeError

--- a/dgbpy/onnx_classes.py
+++ b/dgbpy/onnx_classes.py
@@ -34,7 +34,7 @@ def __output_names( onnx_model ):
     return [out.name for out in onnx_model.graph.output]
 
 def __num_outputs( onnx_model ):
-    return len(onnx_model.graph.input)
+    return len(onnx_model.graph.output)
 
 def model_info( modelfnm ):
     model = onnx.load( modelfnm )

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -731,14 +731,14 @@ class ResidualBlock(nn.Module):
         self.initialize_weights()
         
     def forward(self, X):
-        Y = F.relu(self.bn1(self.conv1(X)))
+        Y = self.relu(self.bn1(self.conv1(X)))
         Y = self.bn2(self.conv2(Y))
         
         if self.conv3:
             X = self.conv3(X)
         
         Y += X
-        return F.relu(Y)
+        return self.relu(Y)
     
     def shape_computation(self, X):
         Y = self.conv1(X)
@@ -1289,41 +1289,43 @@ class UNet_VGG19(nn.Module):
 
         self.activation = nn.Sigmoid() if out_channels == 1 else nn.Softmax(dim=1)
 
+        self.relu = nn.ReLU()
+
 
     def forward(self, x):
         # Encoder
-        conv1 = nn.ReLU()(self.conv1_1(x))
-        conv1 = nn.ReLU()(self.conv1_2(conv1))
+        conv1 = self.relu(self.conv1_1(x))
+        conv1 = self.relu(self.conv1_2(conv1))
         pool1 = self.pool1(conv1)
 
-        conv2 = nn.ReLU()(self.conv2_1(pool1))
-        conv2 = nn.ReLU()(self.conv2_2(conv2))
+        conv2 = self.relu(self.conv2_1(pool1))
+        conv2 = self.relu(self.conv2_2(conv2))
         pool2 = self.pool2(conv2)
 
-        conv3 = nn.ReLU()(self.conv3_1(pool2))
-        conv3 = nn.ReLU()(self.conv3_2(conv3))
-        conv3 = nn.ReLU()(self.conv3_3(conv3))
+        conv3 = self.relu(self.conv3_1(pool2))
+        conv3 = self.relu(self.conv3_2(conv3))
+        conv3 = self.relu(self.conv3_3(conv3))
         pool3 = self.pool3(conv3)
 
-        conv4 = nn.ReLU()(self.conv4_1(pool3))
-        conv4 = nn.ReLU()(self.conv4_2(conv4))
-        conv4 = nn.ReLU()(self.conv4_3(conv4))
+        conv4 = self.relu(self.conv4_1(pool3))
+        conv4 = self.relu(self.conv4_2(conv4))
+        conv4 = self.relu(self.conv4_3(conv4))
 
         # Decoder
         up5 = nn.functional.interpolate(conv4, scale_factor=2, mode='bilinear', align_corners=False)
         up5 = torch.cat([up5, conv3], dim=1)
-        conv5 = nn.ReLU()(self.conv5_1(up5))
-        conv5 = nn.ReLU()(self.conv5_2(conv5))
+        conv5 = self.relu(self.conv5_1(up5))
+        conv5 = self.relu(self.conv5_2(conv5))
 
         up6 = nn.functional.interpolate(conv5, scale_factor=2, mode='bilinear', align_corners=False)
         up6 = torch.cat([up6, conv2], dim=1)
-        conv6 = nn.ReLU()(self.conv6_1(up6))
-        conv6 = nn.ReLU()(self.conv6_2(conv6))
+        conv6 = self.relu(self.conv6_1(up6))
+        conv6 = self.relu(self.conv6_2(conv6))
 
         up7 = nn.functional.interpolate(conv6, scale_factor=2, mode='bilinear', align_corners=False)
         up7 = torch.cat([up7, conv1], dim=1)
-        conv7 = nn.ReLU()(self.conv7_1(up7))
-        conv7 = nn.ReLU()(self.conv7_2(conv7))
+        conv7 = self.relu(self.conv7_1(up7))
+        conv7 = self.relu(self.conv7_2(conv7))
 
         conv8 = self.conv8(conv7)
         output = self.activation(conv8)

--- a/dgbpy/torch_modelinfo.py
+++ b/dgbpy/torch_modelinfo.py
@@ -1,0 +1,49 @@
+#__________________________________________________________________________
+#
+# (C) dGB Beheer B.V.; (LICENSE) http://opendtect.org/OpendTect_license.txt
+# Date:          Jan 2024
+#
+# _________________________________________________________________________
+# various tools to support import of PyTorch models
+# 
+import json
+import torch
+
+def __model_type( torch_model ):
+    return 'Torch Model'
+
+def __input_shape( torch_model: str ) ->list[int]:
+    return [None,None]
+
+def __output_shape( torch_model ):
+    return [None,None]
+
+def __num_inputs( torch_model ):
+    return len(__input_names(torch_model))
+
+def __input_names( torch_model ):
+    return []
+
+def __output_names( torch_model ):
+    return []
+
+def __num_outputs( torch_model ):
+    return len(__output_names(torch_model))
+
+def model_info( modelfnm ):
+    model = torch.load( modelfnm )
+    mi = model_info_dict( model )
+    return json.dumps(mi)
+
+def model_info_dict( torch_model ):
+    minfo = {}
+    minfo['model_type'] = __model_type(torch_model)
+    minfo['version'] = 1.0
+    minfo['num_inputs'] = __num_inputs(torch_model)
+    minfo['num_outputs'] = __num_outputs(torch_model)
+    minfo['input_names'] = __input_names(torch_model)
+    minfo['output_names'] = __output_names(torch_model)
+    minfo['input_shape'] = [shp if shp else 1 for shp in __input_shape(torch_model)]
+    minfo['output_shape'] = [shp if shp else 1 for shp in __output_shape(torch_model)]
+    minfo['data_format'] = 'channels_first' if minfo['input_shape'][1]<minfo['input_shape'][-1] else 'channels_last'
+    return minfo

--- a/dgbpy/torch_modelinfo.py
+++ b/dgbpy/torch_modelinfo.py
@@ -15,10 +15,14 @@ def __model_type( torch_model ):
 def __model_impl( torch_model ):
     if torch_model.__class__.__name__ == 'RecursiveScriptModule':
         return 'torchscript'
+    elif torch_model.__class__.__name__ == 'OrderedDict':
+        return 'torch'
     return ''
 
 def __model_classname( torch_model ):
-    return torch_model.original_name
+    if hasattr(torch_model, 'original_name'):
+        return torch_model.original_name
+    return ''
 
 def __input_shape( torch_model: str ) ->list[int]:
     return [None,None]
@@ -39,7 +43,10 @@ def __num_outputs( torch_model ):
     return len(__output_names(torch_model))
 
 def model_info( modelfnm ):
-    model = torch.jit.load( modelfnm )
+    try:
+        model = torch.jit.load( modelfnm )
+    except RuntimeError:
+        model = torch.load( modelfnm )
     mi = model_info_dict( model )
     return json.dumps(mi)
 

--- a/dgbpy/torch_modelinfo.py
+++ b/dgbpy/torch_modelinfo.py
@@ -12,6 +12,14 @@ import torch
 def __model_type( torch_model ):
     return 'Torch Model'
 
+def __model_impl( torch_model ):
+    if torch_model.__class__.__name__ == 'RecursiveScriptModule':
+        return 'torchscript'
+    return ''
+
+def __model_classname( torch_model ):
+    return torch_model.original_name
+
 def __input_shape( torch_model: str ) ->list[int]:
     return [None,None]
 
@@ -31,13 +39,15 @@ def __num_outputs( torch_model ):
     return len(__output_names(torch_model))
 
 def model_info( modelfnm ):
-    model = torch.load( modelfnm )
+    model = torch.jit.load( modelfnm )
     mi = model_info_dict( model )
     return json.dumps(mi)
 
 def model_info_dict( torch_model ):
     minfo = {}
     minfo['model_type'] = __model_type(torch_model)
+    minfo['model_impl'] = __model_impl(torch_model)
+    minfo['model_classname'] = __model_classname(torch_model)
     minfo['version'] = 1.0
     minfo['num_inputs'] = __num_inputs(torch_model)
     minfo['num_outputs'] = __num_outputs(torch_model)


### PR DESCRIPTION
This PR will allow dgbpy support loading and saving models with the pt and the default torch model formats.

We'll only support the use of torch scripted models for now, 
`model = torch.jit.script(model)`

This would allow us not to depend on the architecture of the torch model itself while saving or loading the models. 
For more reference: https://pytorch.org/tutorials/beginner/saving_loading_models.html#export-load-model-in-torchscript-format

