### PR TITLE
Force the use of the model scaler during transfer training

### DIFF
--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -193,8 +193,9 @@ class Scaler(Enum):
   Normalization = normalizetypestr
   MinMaxScaler = minmaxtypestr
 
-def isDefaultScaler(scaler, info):
-  if isLogOutput(info) or scaler == globalstdtypestr:
+def isDefaultScaler(scaler, info, uselearntype=True):
+  _isLogOutput = isLogOutput(info) and uselearntype
+  if _isLogOutput or scaler == globalstdtypestr:
     return scaler, True
   return scaler, False
 
@@ -204,6 +205,13 @@ def updateScaleInfo( scaler, info ):
   info[inpscalingdictstr] = scaler
   info[outputunscaledictstr] = doOutputScaling(info)
   return info
+
+def getScalerStr( info ):
+  if isinstance(info,dict):
+    if inpscalingdictstr in info:
+      return info[inpscalingdictstr]
+    return globalstdtypestr
+  return info == inpscalingdictstr 
 
 def doOutputScaling( info ):
   if isImg2Img(info) and isRegression(info):

--- a/dgbpy/mlapply.py
+++ b/dgbpy/mlapply.py
@@ -17,6 +17,7 @@ from odpy.oscommand import printProcessTime
 import dgbpy.keystr as dgbkeys
 import dgbpy.hdf5 as dgbhdf5
 import dgbpy.mlio as dgbmlio
+from dgbpy.transforms import all_scalers
 
 TrainType = Enum( 'TrainType', 'New Resume Transfer', module=__name__ )
 
@@ -312,8 +313,7 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
     if type != TrainType.New:
       log_msg(f"Loading input model from file: {modelin}")
       (model,infos) = dgbmlio.getModel( modelin, fortrain=True, pars=params )
-      scaler = dgbhdf5.getScalerStr(infos)
-      scaler, useDefault = dgbhdf5.isDefaultScaler(scaler, infos, False)
+      scaler, useDefault = dgbhdf5.getScalerStr(infos)
 
     trainingdp = None
     validation_split = 0.2 #Params?
@@ -384,7 +384,7 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
         log_msg('Using a default torch model architecture')
       elif type == TrainType.Transfer:
         log_msg( 'Setting up the torch model for transfer training')
-        params['transform'] = scaler 
+        params = check_scaler( params, scaler )
         model = dgbtorch.transfer( model, infos )
 
       print('--Training Started--', flush=True)
@@ -417,6 +417,31 @@ def doTrain( examplefilenm, platform=dgbkeys.kerasplfnm, type=TrainType.New,
   except Exception as e:
     dgbmlio.announceTrainingFailure()
     raise e
+  
+def check_scaler(params, scaler):
+  """ Checks if the required scaler is present in the transform list
+
+  Parameters:
+    * params (dict): machine learning hyperparameters or parameters options
+    * scaler (str): name of scaler to be used
+
+  Returns:
+    * params: machine learning hyperparameters or parameters options
+  """
+
+  transform = params['transform']
+  if scaler in transform:
+    return params
+  for tr in range(len(transform)):
+    if transform[tr] in all_scalers and transform[tr] != scaler:
+      transform[tr] = scaler
+      params['transform'] = transform
+      return params
+  transform.append(scaler)
+  params['transform'] = transform
+  return params
+
+
 
 def reformat( res, applyinfo ):
   """ For reformatting prediction result type(s)

--- a/dgbpy/transforms.py
+++ b/dgbpy/transforms.py
@@ -260,6 +260,7 @@ class MinMaxScaler(ScaleTransform, BaseTransform):
         return self.scale(arr, self.scaler)        
 
 
+all_scalers = (dgbkeys.globalstdtypestr, dgbkeys.localstdtypestr, dgbkeys.normalizetypestr, dgbkeys.minmaxtypestr)
 
 scale_transforms = {
     dgbkeys.localstdtypestr: StandardScaler,

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -11,6 +11,7 @@ from dgbpy.transforms import hasOpenCV
 import dgbpy.keystr as dgbkeys
 from dgbpy import uibokeh
 from dgbpy.dgbtorch import *
+from dgbpy.transforms import all_scalers
 
 info = None
 
@@ -201,11 +202,10 @@ def getUiTransforms(advtorchgrp):
   return transforms
 
 def getUiScaler(advtorchgrp):
-  scalers = (dgbkeys.globalstdtypestr, dgbkeys.localstdtypestr, dgbkeys.normalizetypestr, dgbkeys.minmaxtypestr)
   selectedOption = 0
   if 'scalingfld' in advtorchgrp:
     selectedOption = advtorchgrp['scalingfld'].active
-  return scalers[selectedOption]
+  return all_scalers[selectedOption]
 
 def getUiParams( torchpars, advtorchpars ):
   torchgrp = torchpars['uiobjects']     


### PR DESCRIPTION
This PR is a quick fix to help ensure that the proper scaling method in used for finetuning models in mlapply.doTrain()