### PR TITLE
Change scaling type to model scaler during transfer training

### DIFF
--- a/dgbpy/bokeh_apps/trainui/main.py
+++ b/dgbpy/bokeh_apps/trainui/main.py
@@ -91,6 +91,11 @@ def training_app(doc):
         odcommon.log_msg(f'Change pretrained input model to "{val}".')
         if os.path.isfile(val):
           trainingpars['Input Model File'] = val
+          model_info = dgbmlio.getInfo( val, quick=True )
+          info['disable_scaling'] = True # Disable scaling for pretrained models
+          info[dgbkeys.inpscalingdictstr] = model_info[dgbkeys.inpscalingdictstr]
+          set_info()
+          doc.add_next_tick_callback(partial(updateUI))
         else:
           trainingpars['Input Model File'] = None
       elif key=='ProcLog File':
@@ -262,7 +267,9 @@ def training_app(doc):
   def updateUI():
     nonlocal platformfld
     if info[dgbkeys.learntypedictstr] == dgbkeys.seisimgtoimgtypestr:
-      platformfld.options.remove( uisklearn.getPlatformNm(True) )
+      sklearnplatform = uisklearn.getPlatformNm(True)
+      if sklearnplatform in platformfld.options:
+        platformfld.options.remove( sklearnplatform )
       if platformfld.value == uisklearn.getPlatformNm(False):
         platformfld.value = get_default_platform(info[dgbkeys.learntypedictstr])
     else:

--- a/dgbpy/uitorch.py
+++ b/dgbpy/uitorch.py
@@ -125,7 +125,20 @@ def getUiPars(uipars=None):
   decimateCB( uiobjs['chunkfld'],uiobjs['sizefld'], None,None,uiobjs['dodecimatefld'].active )
   return uipars
 
+def setup_scaler_ui(info):
+  scaler = dgbhdf5.getScalerStr(info)
+  if 'disable_scaling' in info and info['disable_scaling']:
+    return True, scaler
+  return False, scaler
+
+def get_scaler_ui_option(scaler):
+  scalers = [dgbkeys.globalstdtypestr, dgbkeys.localstdtypestr, dgbkeys.normalizetypestr, dgbkeys.minmaxtypestr]
+  if not scaler:
+    return scalers.index(dgbkeys.globalstdtypestr)
+  return scalers.index(scaler)
+
 def createAdvanedUiLeftPane():
+  disable_scaling, scaler = setup_scaler_ui(info)
   uiobjs = {
     'tofp16fld': CheckboxGroup(labels=['Use Mixed Precision'], visible=can_use_gpu(), margin=(5, 5, 0, 5)),
     'tensorboardfld': CheckboxGroup(labels=['Enable Tensorboard'], visible=True, margin=(5, 5, 0, 5)),
@@ -136,7 +149,7 @@ def createAdvanedUiLeftPane():
     transformUi = {
       'scalingheadfld' :Div(text="""<strong>Data Scaling</strong>""", height = 10),
       'scalingfld': RadioGroup(labels=[dgbkeys.globalstdtypestr, dgbkeys.localstdtypestr, dgbkeys.normalizetypestr, dgbkeys.minmaxtypestr],
-                              active=0, margin = [5, 5, 5, 25]),
+                            active=get_scaler_ui_option(scaler), margin = [5, 5, 5, 25], disabled=disable_scaling),
       'augmentheadfld': Div(text="""<strong>Data Augmentation</strong>""", height = 10),
       'augmentfld': CheckboxGroup(labels=aug_labels, visible=True, margin=(5, 5, 5, 25)),
     }


### PR DESCRIPTION
This pull request automates the selection of the appropriate scaling method during Transfer Training in the Bokeh UI interface. The method is determined based on the scaling used to train the model being fine-tuned. Additionally, the PR disables the scaling option to prevent users from inadvertently changing this setting.