### PR TITLE
Fix ui reload (Transfer TrainType to New TrainType)

### DIFF
--- a/dgbpy/bokeh_apps/trainui/main.py
+++ b/dgbpy/bokeh_apps/trainui/main.py
@@ -90,6 +90,10 @@ def training_app(doc):
         if val == dgbmlapply.TrainType.New.name:
           trainingpars['Training Type'] = dgbmlapply.TrainType.New
           trainingpars['Input Model File'] = None
+          if trainingpars['Examples File']:
+            info = dgbmlio.getInfo( trainingpars['Examples File'], quick=True )
+            set_info()
+            doc.add_next_tick_callback(partial(updateUI))
         elif val == dgbmlapply.TrainType.Resume.name:
           trainingpars['Training Type'] = dgbmlapply.TrainType.Resume
         elif val == dgbmlapply.TrainType.Transfer.name:

--- a/dgbpy/bokeh_apps/trainui/trainui.py
+++ b/dgbpy/bokeh_apps/trainui/trainui.py
@@ -73,7 +73,8 @@ def get_default_info():
     dbk.exampledictstr: get_default_examples(),
     dbk.inputdictstr: get_default_input(),
     dbk.filedictstr: 'dummy',
-    dbk.estimatedsizedictstr: 1
+    dbk.estimatedsizedictstr: 1,
+    dbk.inpscalingdictstr : dbk.globalstdtypestr
   }
   return retinfo
 


### PR DESCRIPTION
This PR ensures the automated selection of parameters like scaling type in Transfer Traintype are all being `reset` when the user decides to go back to a New TrainType workflow.