### PR TITLE
Remove Last Activation For VGG19 Regression - Torch

### DIFF
--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -386,7 +386,7 @@ def get_model_architecture(model, model_classname, infos):
     model_instance = UNet(out_channels=nroutputs, dim=dims, in_channels=attribs, n_blocks=1)
   elif model_classname == 'UNet_VGG19':
     from dgbpy.torch_classes import UNet_VGG19
-    model_instance = UNet_VGG19(model_shape, nroutputs, attribs)
+    model_instance = UNet_VGG19(model_shape, nroutputs, attribs, predtype)
   elif model_classname == 'GraphModule':
     model_instance = torch.jit.trace(model.cpu(), dummy_input)
   elif model_classname == 'OnnxTorchModel':

--- a/dgbpy/mlmodel_torch_dGB.py
+++ b/dgbpy/mlmodel_torch_dGB.py
@@ -151,7 +151,7 @@ class dGB_UNetSeg_VGG19(TorchUserModel):
   def _make_model(self, model_shape, nroutputs, nrattributes):
     from dgbpy.dgbtorch import getModelDims
     ndim = getModelDims(model_shape, 'channels_first')
-    model = UNet_VGG19(model_shape=model_shape, out_channels=nroutputs, nrattribs=nrattributes)
+    model = UNet_VGG19(model_shape=model_shape, out_channels=nroutputs, nrattribs=nrattributes, predtype=self.predtype)
     return model
 
 class dGB_UNetReg_VGG19(TorchUserModel):
@@ -164,5 +164,5 @@ class dGB_UNetReg_VGG19(TorchUserModel):
   def _make_model(self, model_shape, nroutputs, nrattributes):
     from dgbpy.dgbtorch import getModelDims
     ndim = getModelDims(model_shape, 'channels_first')
-    model = UNet_VGG19(model_shape=model_shape, out_channels=nroutputs, nrattribs=nrattributes)
+    model = UNet_VGG19(model_shape=model_shape, out_channels=nroutputs, nrattribs=nrattributes, predtype=self.predtype)
     return model

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -1233,7 +1233,7 @@ class UNet(nn.Module):
 
 
 class UNet_VGG19(nn.Module):
-    def __init__(self, model_shape, out_channels, nrattribs):
+    def __init__(self, model_shape, out_channels, nrattribs, predtype):
         super(UNet_VGG19, self).__init__()
 
         filtersz1 = 64
@@ -1243,6 +1243,7 @@ class UNet_VGG19(nn.Module):
         filtersz5 = 32
         filtersz6 = 16
 
+        self.predtype = predtype
         params = dict(kernel_size=3, padding=1)
 
         # Encoder
@@ -1319,7 +1320,9 @@ class UNet_VGG19(nn.Module):
         conv7 = self.relu(self.conv7_2(conv7))
 
         conv8 = self.conv8(conv7)
-        output = self.activation(conv8)
+
+        if self.predtype == DataPredType.Classification:
+            output = self.activation(conv8)
 
         return output
 

--- a/dgbpy/torch_classes.py
+++ b/dgbpy/torch_classes.py
@@ -1322,9 +1322,9 @@ class UNet_VGG19(nn.Module):
         conv8 = self.conv8(conv7)
 
         if self.predtype == DataPredType.Classification:
-            output = self.activation(conv8)
+            return self.activation(conv8)
 
-        return output
+        return conv8
 
 
 class TrainDatasetClass(Dataset):


### PR DESCRIPTION
This PR ensures that the sigmoid/softmax activation is not used for VGG19 regression architecture