### PR TITLE
Fix getTotalSize from examplefile

### DIFF
--- a/dgbpy/hdf5.py
+++ b/dgbpy/hdf5.py
@@ -819,6 +819,8 @@ def getTotalSize( info ):
       nrpts += len(grp)
       continue
     for collnm in collection:
+      if not collnm in grp:
+        continue
       nrpts += len(grp[collnm][xdatadictstr])
   h5file.close()
   examplesshape = get_np_shape( inpshape, nrpts, inpnrattribs )


### PR DESCRIPTION
In somecases, some of the collectionnames are in the examplefile actually are not present in h5file[groupnm]. This PR ensures that this cases does not disrupt the loading and training of such datasets following other previous fix implementations.