### PR TITLE
Ensure tofp16 is False by default

### DIFF
--- a/dgbpy/dgbkeras.py
+++ b/dgbpy/dgbkeras.py
@@ -89,7 +89,7 @@ keras_dict = {
   'scale': dgbkeys.globalstdtypestr,
   'withtensorboard': withtensorboard,
   'tblogdir': None,
-  'tofp16': True,
+  'tofp16': False,
   'userandomseed': 42,
   'stopaftercurrentepoch': False,
   'summary': None

--- a/dgbpy/dgbtorch.py
+++ b/dgbpy/dgbtorch.py
@@ -116,7 +116,7 @@ torch_dict = {
     'transform':default_transforms,
     'withtensorboard': withtensorboard,
     'tblogdir': None,
-    'tofp16': True,
+    'tofp16': False,
     'userandomseed': 42,
     'stopaftercurrentepoch': False,
     'tmpsavedict': tmp_save_dict,


### PR DESCRIPTION
Mixed precision is an experimental feature and should be set to False by default for all platforms.